### PR TITLE
rename patch status to patch state

### DIFF
--- a/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
+++ b/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
@@ -44,7 +44,7 @@ import org.jboss.set.aphrodite.domain.Comment;
 import org.jboss.set.aphrodite.domain.Issue;
 import org.jboss.set.aphrodite.domain.Label;
 import org.jboss.set.aphrodite.domain.Patch;
-import org.jboss.set.aphrodite.domain.PatchStatus;
+import org.jboss.set.aphrodite.domain.PatchState;
 import org.jboss.set.aphrodite.domain.Repository;
 import org.jboss.set.aphrodite.domain.SearchCriteria;
 import org.jboss.set.aphrodite.spi.AphroditeException;
@@ -390,20 +390,20 @@ public class Aphrodite implements AutoCloseable {
 
     /**
      * Retrieve all Patches associated with the provided <code>Repository</code> object, which have a
-     * status that matches the provided <code>PatchStatus</code> object.
+     * state that matches the provided <code>PatchState</code> object.
      *
      * @param repository the <code>Repository</code> object whose associated Patches should be returned.
-     * @param status the <code>PatchStatus</code> which the returned <code>Patch</code> objects must have.
+     * @param state the <code>PatchState</code> which the returned <code>Patch</code> objects must have.
      * @return a list of all matching <code>Patch</code> objects, or an empty list if no patches can be found.
      */
-    public List<Patch> getPatchesByStatus(Repository repository, PatchStatus status) {
+    public List<Patch> getPatchesByState(Repository repository, PatchState state) {
         checkRepositoryServiceExists();
         Objects.requireNonNull(repository, "repository cannot be null");
-        Objects.requireNonNull(status, "status cannot be null");
+        Objects.requireNonNull(state, "state cannot be null");
 
         for (RepositoryService repositoryService : repositories) {
             try {
-                return repositoryService.getPatchesByStatus(repository, status);
+                return repositoryService.getPatchesByState(repository, state);
             } catch (NotFoundException e) {
                 if (LOG.isInfoEnabled())
                     LOG.info("No patches found at RepositoryService: " + repositoryService.getClass().getName(), e);

--- a/src/main/java/org/jboss/set/aphrodite/domain/Patch.java
+++ b/src/main/java/org/jboss/set/aphrodite/domain/Patch.java
@@ -29,23 +29,23 @@ public class Patch {
     private final String id;
     private final URL url;
     private final Codebase codebase;
-    private PatchStatus status;
+    private PatchState state;
     private String title;
     private String body;
     private Repository repository;
 
-    public Patch(String id, URL url, Repository repository, Codebase codebase, PatchStatus status, String title, String body) {
+    public Patch(String id, URL url, Repository repository, Codebase codebase, PatchState state, String title, String body) {
         this.id = id;
         this.url = url;
         this.codebase = codebase;
-        this.status = status;
+        this.state = state;
         this.title = title;
         this.body = body;
         this.repository = repository;
     }
 
-    public Patch(String id, URL url, Repository repository, Codebase codebase, PatchStatus status) {
-        this(id, url, repository, codebase, status, null, null);
+    public Patch(String id, URL url, Repository repository, Codebase codebase, PatchState state) {
+        this(id, url, repository, codebase, state, null, null);
 
     }
 
@@ -62,12 +62,12 @@ public class Patch {
         return codebase;
     }
 
-    public PatchStatus getStatus() {
-        return status;
+    public PatchState getState() {
+        return state;
     }
 
-    public void setStatus(PatchStatus status) {
-        this.status = status;
+    public void setState(PatchState state) {
+        this.state = state;
     }
 
     public String getTitle() {
@@ -99,7 +99,7 @@ public class Patch {
     public String toString() {
         return "Patch{" +
                 "url=" + url +
-                ", status=" + status +
+                ", state=" + state +
                 ", title='" + title + '\'' +
                 ", body='" + body + '\'' +
                 ", codebase=" + codebase +

--- a/src/main/java/org/jboss/set/aphrodite/domain/PatchState.java
+++ b/src/main/java/org/jboss/set/aphrodite/domain/PatchState.java
@@ -22,6 +22,6 @@
 
 package org.jboss.set.aphrodite.domain;
 
-public enum PatchStatus {
+public enum PatchState {
     UNDEFINED, OPEN, CLOSED
 }

--- a/src/main/java/org/jboss/set/aphrodite/repository/services/common/AbstractRepositoryService.java
+++ b/src/main/java/org/jboss/set/aphrodite/repository/services/common/AbstractRepositoryService.java
@@ -28,7 +28,7 @@ import org.jboss.set.aphrodite.config.AphroditeConfig;
 import org.jboss.set.aphrodite.config.RepositoryConfig;
 import org.jboss.set.aphrodite.domain.Issue;
 import org.jboss.set.aphrodite.domain.Patch;
-import org.jboss.set.aphrodite.domain.PatchStatus;
+import org.jboss.set.aphrodite.domain.PatchState;
 import org.jboss.set.aphrodite.domain.Repository;
 import org.jboss.set.aphrodite.spi.NotFoundException;
 import org.jboss.set.aphrodite.spi.RepositoryService;
@@ -100,7 +100,7 @@ public abstract class AbstractRepositoryService implements RepositoryService {
     }
 
     @Override
-    public List<Patch> getPatchesByStatus(Repository repository, PatchStatus status) throws NotFoundException {
+    public List<Patch> getPatchesByState(Repository repository, PatchState state) throws NotFoundException {
         throw new UnsupportedOperationException("Not yet implemented.");
     }
 

--- a/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
+++ b/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
@@ -49,7 +49,7 @@ import org.jboss.set.aphrodite.common.Utils;
 import org.jboss.set.aphrodite.config.RepositoryConfig;
 import org.jboss.set.aphrodite.domain.Issue;
 import org.jboss.set.aphrodite.domain.Patch;
-import org.jboss.set.aphrodite.domain.PatchStatus;
+import org.jboss.set.aphrodite.domain.PatchState;
 import org.jboss.set.aphrodite.domain.Repository;
 import org.jboss.set.aphrodite.repository.services.common.AbstractRepositoryService;
 import org.jboss.set.aphrodite.repository.services.common.RepositoryType;
@@ -151,15 +151,15 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
     }
 
     @Override
-    public List<Patch> getPatchesByStatus(Repository repository, PatchStatus status) throws NotFoundException {
+    public List<Patch> getPatchesByState(Repository repository, PatchState state) throws NotFoundException {
         URL url = repository.getURL();
         checkHost(url);
 
         RepositoryId id = RepositoryId.createFromUrl(url);
         PullRequestService pullRequestService = new PullRequestService(gitHubClient);
         try {
-            String githubStatus = status.toString().toLowerCase();
-            List<PullRequest> pullRequests = pullRequestService.getPullRequests(id, githubStatus);
+            String githubState = state.toString().toLowerCase();
+            List<PullRequest> pullRequests = pullRequestService.getPullRequests(id, githubState);
             return WRAPPER.toAphroditePatches(pullRequests);
         } catch (IOException e) {
             Utils.logException(LOG, e);

--- a/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubWrapper.java
+++ b/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubWrapper.java
@@ -26,7 +26,7 @@ import org.eclipse.egit.github.core.PullRequest;
 import org.eclipse.egit.github.core.RepositoryBranch;
 import org.jboss.set.aphrodite.domain.Codebase;
 import org.jboss.set.aphrodite.domain.Patch;
-import org.jboss.set.aphrodite.domain.PatchStatus;
+import org.jboss.set.aphrodite.domain.PatchState;
 import org.jboss.set.aphrodite.domain.Repository;
 import org.jboss.set.aphrodite.domain.Label;
 
@@ -62,7 +62,7 @@ class GitHubWrapper {
             String id = Integer.toString(pullRequest.getNumber());
             URL url = new URL(pullRequest.getHtmlUrl());
             Codebase codebase = new Codebase(pullRequest.getBase().getRef());
-            PatchStatus status = getPatchStatus(pullRequest.getState());
+            PatchState state = getPatchState(pullRequest.getState());
             String title = pullRequest.getTitle().replaceFirst("\\u2026", "");
             String body = pullRequest.getBody().replaceFirst("\\u2026", "");
 
@@ -73,7 +73,7 @@ class GitHubWrapper {
             }
             Repository repo = new Repository(URI.create(urlString).toURL());
 
-            return new Patch(id, url, repo, codebase, status, title, body);
+            return new Patch(id, url, repo, codebase, state, title, body);
         } catch (MalformedURLException e) {
             return null;
         }
@@ -91,11 +91,11 @@ class GitHubWrapper {
         return patchLabels;
     }
 
-    private PatchStatus getPatchStatus(String status) {
+    private PatchState getPatchState(String state) {
         try {
-            return PatchStatus.valueOf(status.toUpperCase());
+            return PatchState.valueOf(state.toUpperCase());
         } catch (IllegalArgumentException e) {
-            return PatchStatus.UNDEFINED;
+            return PatchState.UNDEFINED;
         }
     }
 

--- a/src/main/java/org/jboss/set/aphrodite/spi/RepositoryService.java
+++ b/src/main/java/org/jboss/set/aphrodite/spi/RepositoryService.java
@@ -30,7 +30,7 @@ import org.jboss.set.aphrodite.config.RepositoryConfig;
 import org.jboss.set.aphrodite.domain.Issue;
 import org.jboss.set.aphrodite.domain.Label;
 import org.jboss.set.aphrodite.domain.Patch;
-import org.jboss.set.aphrodite.domain.PatchStatus;
+import org.jboss.set.aphrodite.domain.PatchState;
 import org.jboss.set.aphrodite.domain.Repository;
 
 public interface RepositoryService {
@@ -85,14 +85,14 @@ public interface RepositoryService {
 
     /**
      * Retrieve all Patches associated with the provided <code>Repository</code> object, which have a
-     * status that matches the provided <code>PatchStatus</code> object.
+     * state that matches the provided <code>PatchState</code> object.
      *
      * @param repository the <code>Repository</code> object whose associated Patches should be returned.
-     * @param status the <code>PatchStatus</code> which the returned <code>Patch</code> objects must have.
+     * @param state the <code>PatchState</code> which the returned <code>Patch</code> objects must have.
      * @return a list of all matching <code>Patch</code> objects, or an empty list if no patches can be found.
      * @throws NotFoundException if the provided <code>Repository</code> cannot be found at the RepositoryService.
      */
-    List<Patch> getPatchesByStatus(Repository repository, PatchStatus status) throws NotFoundException;
+    List<Patch> getPatchesByState(Repository repository, PatchState state) throws NotFoundException;
 
     /**
      * Retrieve all labels associated with the provided <code>Patch</code> in <code>Repository</code> object.


### PR DESCRIPTION
Maoqian is working on https://github.com/jboss-set/aphrodite/issues/21 to add Status API as per described in https://developer.github.com/v3/repos/statuses/

According to https://developer.github.com/v3/pulls/, the previous patch status notion is not accurate and confusing once https://github.com/jboss-set/aphrodite/issues/21 is resolved. 

> **statuses** 	The API location of this Pull Request's commit statuses, which are the statuses of its head branch.
> **state** 	string 	Either open, closed, or all to filter by state. Default: open

rename previous patch status to patch state.