### PR TITLE
Issue#42 - Execute requests across multiple services in parallel

### DIFF
--- a/aphrodite.properties.json.example
+++ b/aphrodite.properties.json.example
@@ -1,4 +1,5 @@
 {
+    "maxThreadCount": "10",
     "issueTrackerConfigs": [
         {
             "url": "https://issues.jboss.org/",

--- a/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
+++ b/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
@@ -27,6 +27,11 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -100,14 +105,16 @@ public class Aphrodite implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        issueTrackers.forEach(e -> e.destroy());
+        executorService.shutdown();
+        issueTrackers.forEach(IssueTrackerService::destroy);
         issueTrackers.clear();
-        repositories.forEach(e -> e.destroy());
+        repositories.forEach(RepositoryService::destroy);
         repositories.clear();
     }
 
     private final List<IssueTrackerService> issueTrackers = new ArrayList<>();
     private final List<RepositoryService> repositories = new ArrayList<>();
+    private ExecutorService executorService;
 
     private AphroditeConfig config;
 
@@ -131,6 +138,7 @@ public class Aphrodite implements AutoCloseable {
     private void init(AphroditeConfig config) throws AphroditeException {
         this.config = config;
 
+        executorService = config.getExecutorService();
         // Create new config object, as the object passed to init() will have its state changed.
         AphroditeConfig mutableConfig = new AphroditeConfig(config);
 
@@ -186,15 +194,14 @@ public class Aphrodite implements AutoCloseable {
     public List<Issue> getIssues(Collection<URL> urls) {
         Objects.requireNonNull(urls, "the collection of urls cannot be null");
 
-        List<Issue> issues = new ArrayList<>();
         if (urls.isEmpty())
-            return issues;
+            return new ArrayList<>();
 
-        issues = issueTrackers.stream()
-                .map(tracker -> tracker.getIssues(urls))
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
-        return issues;
+        List<Callable<List<Issue>>> requests = new ArrayList<>(issueTrackers.size());
+        for (IssueTrackerService tracker : issueTrackers)
+            requests.add(() -> tracker.getIssues(urls));
+
+        return getIssuesInParallel(requests);
     }
 
     /**
@@ -208,8 +215,28 @@ public class Aphrodite implements AutoCloseable {
         Objects.requireNonNull(searchCriteria, "searchCriteria cannot be null");
         checkIssueTrackerExists();
 
+        List<Callable<List<Issue>>> searchRequests = new ArrayList<>(issueTrackers.size());
+        for (IssueTrackerService tracker : issueTrackers)
+            searchRequests.add(() -> tracker.searchIssues(searchCriteria));
+
+        return getIssuesInParallel(searchRequests);
+    }
+
+    private List<Issue> getIssuesInParallel(List<Callable<List<Issue>>> callables) {
         List<Issue> issues = new ArrayList<>();
-        issueTrackers.forEach(tracker -> issues.addAll(tracker.searchIssues(searchCriteria)));
+        try {
+            List<Future<List<Issue>>> futures = executorService.invokeAll(callables);
+            for (Future<List<Issue>> result : futures) {
+                try {
+                    issues.addAll(result.get());
+                } catch (ExecutionException | CancellationException | InterruptedException e) {
+                    if (LOG.isWarnEnabled())
+                        LOG.warn("Exception encountered when processing request future: " + e);
+                }
+            }
+        } catch (InterruptedException e) {
+            LOG.error("Issue search interrupted unexpectedly: " + e);
+        }
         return issues;
     }
 

--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaIssueTracker.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaIssueTracker.java
@@ -62,7 +62,7 @@ public class BugzillaIssueTracker extends AbstractIssueTracker {
             return false;
 
         try {
-            bzClient = new BugzillaClient(baseUrl, config.getUsername(), config.getPassword());
+            bzClient = new BugzillaClient(baseUrl, config.getUsername(), config.getPassword(), executorService);
         } catch (IllegalStateException e) {
             Utils.logException(LOG, e);
             return false;

--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/common/AbstractIssueTracker.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/common/AbstractIssueTracker.java
@@ -41,6 +41,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -55,6 +56,7 @@ public abstract class AbstractIssueTracker implements IssueTrackerService {
             .compile("(http|ftp|https)://([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])?");
 
     protected final TrackerType TRACKER_TYPE;
+    protected ExecutorService executorService;
     protected IssueTrackerConfig config;
     protected URL baseUrl;
 
@@ -66,6 +68,8 @@ public abstract class AbstractIssueTracker implements IssueTrackerService {
 
     @Override
     public boolean init(AphroditeConfig aphroditeConfig) {
+        executorService = aphroditeConfig.getExecutorService();
+
         Iterator<IssueTrackerConfig> i = aphroditeConfig.getIssueTrackerConfigs().iterator();
         while (i.hasNext()) {
             IssueTrackerConfig config = i.next();


### PR DESCRIPTION
This affects Aphrodite::searchIssues and Aphrodite::getIssues

The maximum number of additional threads created by Aphrodite is now configurable in the json configuration file. Alternatively, an ExecutorService which is used to execute all Aphrodite runnables can be passed to the AphroditeConfig object when configuring programatically.