### PR TITLE
ignore svn repository and less strict on repository codebase matching.

### DIFF
--- a/src/main/java/org/jboss/set/aphrodite/JsonStreamService.java
+++ b/src/main/java/org/jboss/set/aphrodite/JsonStreamService.java
@@ -124,16 +124,18 @@ public class JsonStreamService implements StreamService {
             String componentName = json.getString("component_name");
             String codebaseName = json.getString("codebase");
             URL repositoryUrl = parseUrl(json.getString("repository_url"));
-
-            Repository repository = aphrodite.getRepository(repositoryUrl);
-            Codebase codebase = new Codebase(codebaseName);
-
-            if (!repository.getCodebases().contains(codebase))
-                throw new NotFoundException("The specified codebase '" + codebaseName + "' " +
-                        "does not belong to the Repository at " + repository.getURL());
-
-            StreamComponent component = new StreamComponent(componentName, repository, codebase);
-            codebaseMap.put(component.getName(), component);
+            // ignore until it supports svn repository
+            if (!repositoryUrl.toString().contains("svn.jboss.org")) {
+                Repository repository = aphrodite.getRepository(repositoryUrl);
+                Codebase codebase = new Codebase(codebaseName);
+                if (!repository.getCodebases().contains(codebase)) {
+                    Utils.logWarnMessage(LOG, "The specified codebase '" + codebaseName + "' " +
+                            "does not belong to the Repository at " + repository.getURL());
+                } else {
+                    StreamComponent component = new StreamComponent(componentName, repository, codebase);
+                    codebaseMap.put(component.getName(), component);
+                }
+            }
         }
         return codebaseMap;
     }


### PR DESCRIPTION
ignore svn repository in streams, otherwise there will be an exception due to miss matching host.
for the moment, the only repository stays on svn is jbossweb for EAP 6, not sure if it's worthy to be implemented.

current repository and codebase checking will throw NotFoundException, it's too strict since it's likely stream.json disaccords with branches on github later on. e.g. https://github.com/jboss-set/jboss-streams/commit/b127b122815abc14d62aa67739fd59a4c2309269