### PR TITLE
Use email adress for reporter in JIRA like in Bugzilla

### DIFF
--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/IssueWrapper.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/IssueWrapper.java
@@ -217,7 +217,7 @@ class IssueWrapper {
     private void setIssueReporter(Issue issue, com.atlassian.jira.rest.client.api.domain.Issue jiraIssue) {
         User reporter = jiraIssue.getReporter();
         if (reporter != null)
-            issue.setReporter(reporter.getName());
+            issue.setReporter(reporter.getEmailAddress());
     }
 
     private void setIssueStage(Issue issue, com.atlassian.jira.rest.client.api.domain.Issue jiraIssue) {


### PR DESCRIPTION
With Bugzilla, the field reporter contains the full email address, while for JIRA we just use the name. It's unconsistent, but more importantly the email information is important (for instance for the following BugClerk check [CommunityBZ](https://github.com/jboss-set/bug-clerk/blob/master/src/main/resources/org/jboss/jbossset/bugclerk/CommunityBZ.drl))

_Note: To be even more consistent, we could rename the "reporter" field into reporterEmail (or go even further and create a full blown Reporter object, similar to the one provided by JIRA. But honestly, let's not - and keep it simple. Personaly, I can reconcile with the reporter field being an email address._