### PR TITLE
Add a field trackerType on Issue, so that client can figure out easily where the issue comes from

### DIFF
--- a/src/main/java/org/jboss/set/aphrodite/domain/Issue.java
+++ b/src/main/java/org/jboss/set/aphrodite/domain/Issue.java
@@ -22,6 +22,8 @@
 
 package org.jboss.set.aphrodite.domain;
 
+import org.jboss.set.aphrodite.config.TrackerType;
+
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Date;
@@ -42,6 +44,8 @@ public class Issue {
 
     // The unique id of an issue within its issue tracker domain e.g WFLY-5048
     private String trackerId;
+
+    private final TrackerType trackerType;
 
     private String product; // E.g EAP6
 
@@ -77,11 +81,12 @@ public class Issue {
 
     private List<Comment> comments;
 
-    public Issue(URL url) {
+    public Issue(URL url, TrackerType type) {
         if (url == null)
             throw new IllegalArgumentException("Issue URL cannot be null");
 
         this.url = url;
+        this.trackerType = type;
         this.stage = new Stage();
         this.status = IssueStatus.UNDEFINED;
         this.type = IssueType.UNDEFINED;
@@ -103,6 +108,10 @@ public class Issue {
 
     public void setTrackerId(String trackerId) {
         this.trackerId = trackerId;
+    }
+
+    public TrackerType getTrackerType() {
+        return this.trackerType;
     }
 
     public Optional<String> getProduct() {
@@ -254,6 +263,7 @@ public class Issue {
         return "Issue{" +
                 "url=" + url +
                 ", trackerId='" + trackerId + '\'' +
+                ", trackerType='" + trackerType + '\'' +
                 ", product='" + product + '\'' +
                 ", component='" + components + '\'' +
                 ", summary='" + summary + '\'' +

--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/IssueWrapper.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/IssueWrapper.java
@@ -60,6 +60,7 @@ import java.util.Optional;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jboss.set.aphrodite.common.Utils;
+import org.jboss.set.aphrodite.config.TrackerType;
 import org.jboss.set.aphrodite.domain.Flag;
 import org.jboss.set.aphrodite.domain.FlagStatus;
 import org.jboss.set.aphrodite.domain.Issue;
@@ -81,7 +82,7 @@ class IssueWrapper {
     Issue bugzillaBugToIssue(Map<String, Object> bug, URL baseURL) {
         Integer id = (Integer) bug.get(ID);
         URL url = Utils.createURL(baseURL + ID_QUERY + id);
-        Issue issue = new Issue(url);
+        Issue issue = new Issue(url, TrackerType.BUGZILLA);
         issue.setTrackerId(id.toString());
         issue.setAssignee(User.createWithEmail((String) bug.get(ASSIGNEE)));
         issue.setReporter(User.createWithEmail((String) bug.get(REPORTER)));

--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/IssueWrapper.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/IssueWrapper.java
@@ -48,6 +48,7 @@ import org.apache.commons.logging.LogFactory;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.jboss.set.aphrodite.common.Utils;
+import org.jboss.set.aphrodite.config.TrackerType;
 import org.jboss.set.aphrodite.domain.Comment;
 import org.jboss.set.aphrodite.domain.Flag;
 import org.jboss.set.aphrodite.domain.FlagStatus;
@@ -92,7 +93,7 @@ class IssueWrapper {
     }
 
     Issue jiraIssueToIssue(URL url, com.atlassian.jira.rest.client.api.domain.Issue jiraIssue) {
-        Issue issue = new Issue(url);
+        Issue issue = new Issue(url, TrackerType.JIRA);
 
         issue.setTrackerId(jiraIssue.getKey());
         issue.setSummary(jiraIssue.getSummary());

--- a/src/test/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BZIssueWrapperTest.java
+++ b/src/test/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BZIssueWrapperTest.java
@@ -22,6 +22,7 @@
 
 package org.jboss.set.aphrodite.issue.trackers.bugzilla;
 
+import org.jboss.set.aphrodite.config.TrackerType;
 import org.jboss.set.aphrodite.domain.Flag;
 import org.jboss.set.aphrodite.domain.FlagStatus;
 import org.jboss.set.aphrodite.domain.Issue;
@@ -180,7 +181,7 @@ public class BZIssueWrapperTest {
     }
 
     private Issue createTestIssue01(URL url) throws MalformedURLException, ParseException {
-        Issue result = new Issue(url);
+        Issue result = new Issue(url, TrackerType.BUGZILLA);
 
         result.setTrackerId("1111111");
         result.setAssignee(User.createWithEmail("jboss-set@redhat.com"));

--- a/src/test/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssueWrapperTest.java
+++ b/src/test/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssueWrapperTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
+import org.jboss.set.aphrodite.config.TrackerType;
 import org.jboss.set.aphrodite.domain.Flag;
 import org.jboss.set.aphrodite.domain.FlagStatus;
 import org.jboss.set.aphrodite.domain.Issue;
@@ -200,7 +201,7 @@ public class JiraIssueWrapperTest {
     }
 
     private Issue createTestIssue01(URL url) throws ParseException {
-        Issue result = new Issue(url);
+        Issue result = new Issue(url, TrackerType.JIRA);
 
         result.setTrackerId("1111111");
         result.setSummary("Test Issue");


### PR DESCRIPTION
This is mostly aimed at Bugclerk, to allow it to skip some checks that does not apply to the tracker. It's a proposal, if you don't feel it should integrated, I'll hack that into a static method in Bugclerk code base.