### PR TITLE
Add an UNKNOWN status to present repository without CI configuration.

### DIFF
--- a/src/main/java/org/jboss/set/aphrodite/domain/CommitStatus.java
+++ b/src/main/java/org/jboss/set/aphrodite/domain/CommitStatus.java
@@ -24,7 +24,7 @@ package org.jboss.set.aphrodite.domain;
 
 public enum CommitStatus {
 
-    ERROR("error"), FAILURE("failure"), PENDING("pending"), SUCCESS("success");
+    ERROR("error"), FAILURE("failure"), PENDING("pending"), SUCCESS("success"), UNKNOWN("unknown");
 
     private final String status;
 

--- a/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
+++ b/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
@@ -438,7 +438,7 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
         if (status != null) {
             return status;
         } else {
-            throw new NotFoundException("No commit status found for patch:" + patch.getURL());
+            return org.jboss.set.aphrodite.domain.CommitStatus.UNKNOWN;
         }
     }
 


### PR DESCRIPTION
Some jbossas private maintenance repositories don't have a CI build.