### PR TITLE
Issue #46 - Allow for IssueTracker specific attributes

### DIFF
--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/IssueWrapper.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/IssueWrapper.java
@@ -43,8 +43,10 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.atlassian.jira.rest.client.api.domain.Project;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.jboss.set.aphrodite.common.Utils;
@@ -70,6 +72,7 @@ import com.atlassian.jira.rest.client.api.domain.input.ComplexIssueInputFieldVal
 import com.atlassian.jira.rest.client.api.domain.input.FieldInput;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
+
 import org.jboss.set.aphrodite.spi.NotFoundException;
 
 /**
@@ -93,7 +96,7 @@ class IssueWrapper {
     }
 
     Issue jiraIssueToIssue(URL url, com.atlassian.jira.rest.client.api.domain.Issue jiraIssue) {
-        Issue issue = new Issue(url, TrackerType.JIRA);
+        JiraIssue issue = new JiraIssue(url, TrackerType.JIRA);
 
         issue.setTrackerId(jiraIssue.getKey());
         issue.setSummary(jiraIssue.getSummary());
@@ -121,7 +124,7 @@ class IssueWrapper {
         setIssueComments(issue, jiraIssue);
         setCreationTime(issue, jiraIssue);
         setLastUpdated(issue, jiraIssue);
-
+        setPullRequests(issue,jiraIssue);
         return issue;
     }
 
@@ -285,6 +288,30 @@ class IssueWrapper {
         jiraIssue.getComments()
                 .forEach(c -> comments.add(new Comment(issue.getTrackerId().get(), Long.toString(c.getId()), c.getBody(), false)));
         issue.getComments().addAll(comments);
+    }
+
+    private void setPullRequests(JiraIssue issue, com.atlassian.jira.rest.client.api.domain.Issue jiraIssue) {
+        IssueField fieldContent = jiraIssue.getFieldByName("Git Pull Request");//Git Pull Request
+        if ( fieldContent != null ) {
+            extractPullRequests(issue, (JSONArray) fieldContent.getValue());
+        }
+    }
+
+    private static void extractPullRequests(JiraIssue issue, JSONArray urls) {
+        if (urls.length() > 0 ) {
+            List<URL> prUrls = new ArrayList<URL>(urls.length());
+            for ( int index = 0 ; index < urls.length(); index++ )
+                prUrls.add(Utils.createURL(getFromJSONArray(index,urls).toString()));
+            issue.setPullRequests(prUrls);
+        }
+    }
+
+    private static Object getFromJSONArray(int i, JSONArray urls) {
+        try {
+            return urls.get(i);
+        } catch (JSONException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     private URL trackerIdToBrowsableUrl(URL url, String trackerId) {

--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssue.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssue.java
@@ -1,0 +1,31 @@
+package org.jboss.set.aphrodite.issue.trackers.jira;
+
+import org.jboss.set.aphrodite.config.TrackerType;
+import org.jboss.set.aphrodite.domain.Issue;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by Romain Pelisse <belaran@redhat.com> on 20/04/16.
+ */
+public class JiraIssue extends Issue {
+
+    private List<URL> pullRequests = new ArrayList<URL>();
+
+    public JiraIssue(URL url, TrackerType type) {
+        super(url, type);
+        if ( ! type.equals(TrackerType.JIRA) )
+            throw new IllegalStateException("Can't instantiate if issue is not of JIRA type");
+    }
+
+    public List<URL> getPullRequests() {
+        return pullRequests;
+    }
+
+    public void setPullRequests(List<URL> pullRequests) {
+        this.pullRequests = pullRequests;
+    }
+
+}


### PR DESCRIPTION
Given last comment of @wolfc on #46, I've came back to my original, simple approach, of having a JiraIssue inheriting Issue, that holds the extra fields associated to Jira. 

It's not as generic as the proposed "extendedModel", but it's type-safe, it allows auto-completion, and so on.... Also, IMHO, it will be a bit more friendly for script (or Aphrodite app like Bugclerk).

Note: this PR also fixes #78