### PR TITLE
test repository accessibility.

### DIFF
--- a/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
+++ b/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
@@ -389,7 +389,7 @@ public class Aphrodite implements AutoCloseable {
         Objects.requireNonNull(url, "url cannot be null");
 
         for (RepositoryService repositoryService : repositories) {
-            if (repositoryService.urlExists(url))
+            if (repositoryService.repositoryAccessable(url) && repositoryService.urlExists(url))
                 return repositoryService.getRepository(url);
         }
         throw new NotFoundException("No repositories found which correspond to url: " + url);
@@ -446,7 +446,7 @@ public class Aphrodite implements AutoCloseable {
         Objects.requireNonNull(url, "url cannot be null");
 
         for (RepositoryService repositoryService : repositories) {
-            if (repositoryService.urlExists(url))
+            if (repositoryService.repositoryAccessable(url) && repositoryService.urlExists(url))
                 return repositoryService.getPatch(url);
         }
         throw new NotFoundException("No patch found which corresponds to url: " + url);

--- a/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
+++ b/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
@@ -474,4 +474,22 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
         return (flag == 0) ? "success" : null;
     }
 
+    @Override
+    public boolean repositoryAccessable(URL url) {
+        if (url.toString().contains("svn.jboss.org")) {
+            // svn repository is not supported
+            Utils.logWarnMessage(LOG, "svn repository : " + url + " is not supported.");
+            return false;
+        }
+        RepositoryId id = RepositoryId.createFromUrl(url);
+        RepositoryService rs = new RepositoryService(gitHubClient);
+        try {
+            rs.getBranches(id); // action to test account repository accessibility
+        } catch (IOException e) {
+            Utils.logWarnMessage(LOG,
+                    "repository : " + url + " is not accessable due to " + e.getMessage() + ". Check repository link and your account permission.");
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/main/java/org/jboss/set/aphrodite/spi/RepositoryService.java
+++ b/src/main/java/org/jboss/set/aphrodite/spi/RepositoryService.java
@@ -66,6 +66,13 @@ public interface RepositoryService {
     boolean urlExists(URL url);
 
     /**
+     * Checks whether the provided <code>URL</code> is accessable.
+     * @param url the <code>URL</code> to check.
+     * @return true if the provided <code>URL</code> is accessable, otherwise false.
+     */
+    boolean repositoryAccessable(URL url);
+
+    /**
      * Get the repository located at the provided <code>URL</code>.
      *
      * @param url the <code>URL</code> of the repository to be retrieved.

--- a/src/main/java/org/jboss/set/aphrodite/stream/services/json/JsonStreamService.java
+++ b/src/main/java/org/jboss/set/aphrodite/stream/services/json/JsonStreamService.java
@@ -149,16 +149,16 @@ public class JsonStreamService implements StreamService {
         }
     }
 
-    private Map<String, StreamComponent> parseStreamCodebases(JsonArray codebases) throws NotFoundException {
+    private Map<String, StreamComponent> parseStreamCodebases(JsonArray codebases) {
         Map<String, StreamComponent> codebaseMap = new HashMap<>();
         for (JsonValue value : codebases) {
             JsonObject json = (JsonObject) value;
             String componentName = json.getString("component_name");
             String codebaseName = json.getString("codebase");
             URL repositoryUrl = parseUrl(json.getString("repository_url"));
-            // ignore until it supports svn repository
-            if (!repositoryUrl.toString().contains("svn.jboss.org")) {
-                Repository repository = aphrodite.getRepository(repositoryUrl);
+            Repository repository;
+            try {
+                repository = aphrodite.getRepository(repositoryUrl);
                 Codebase codebase = new Codebase(codebaseName);
                 if (!repository.getCodebases().contains(codebase)) {
                     Utils.logWarnMessage(LOG, "The specified codebase '" + codebaseName + "' " +
@@ -167,6 +167,8 @@ public class JsonStreamService implements StreamService {
                     StreamComponent component = new StreamComponent(componentName, repository, codebase);
                     codebaseMap.put(component.getName(), component);
                 }
+            } catch (NotFoundException e) {
+                Utils.logWarnMessage(LOG, e.getMessage());
             }
         }
         return codebaseMap;


### PR DESCRIPTION
catch possible NotFoundException in case of account pull-processor has no permission to visit internal repository on GitHub. Otherwise, it breaks Aphrodite Stream Service initialization. 