### PR TITLE
correct URL_REGEX pattern which should end with number.

### DIFF
--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/common/AbstractIssueTracker.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/common/AbstractIssueTracker.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractIssueTracker implements IssueTrackerService {
     public static final Pattern URL_REGEX = Pattern
-            .compile("(http|ftp|https)://([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])?");
+            .compile("(http|ftp|https)://([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])?\\d+");
 
     protected final TrackerType TRACKER_TYPE;
     protected ExecutorService executorService;

--- a/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
+++ b/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
@@ -458,7 +458,8 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
             } else {
                 flag = 1;
                 // The Travis CI and TeamCity Build has different rules
-                if (status.getDescription().contains("Travis")) {
+                String description = status.getDescription();
+                if (description != null && description.contains("Travis")) {
                     return stas.contains("success") ? "success" : "pending";
                 }
                 if (comStatuses.size() > 2 * count) {


### PR DESCRIPTION
1. correct url_regex pattern to check end of issue url found in github description/comment is a number to get along with Markdown styling, example case: ~~https://issues.jboss.org/browse/JBEAP-4391~~ found in https://github.com/jbossas/jboss-eap7/pull/460
Markdown Syntax https://guides.github.com/features/mastering-markdown/

2. fix possible NPE for CommitStatus with no description