### PR TITLE
remove unecessary api dependecy and upgrade fugue.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <com.google.guava.version>18.0</com.google.guava.version>
         <commons.logging.version>1.1.3</commons.logging.version>
         <commons.beanutils.version>1.9.2</commons.beanutils.version>
-        <fugue.version>1.1</fugue.version>
+        <fugue.version>2.2.1</fugue.version>
         <javax.json.version>1.0.4</javax.json.version>
         <jira.client.version>4.0.0</jira.client.version>
         <junit.version>4.12</junit.version>
@@ -189,11 +189,6 @@
             <groupId>org.apache.xmlrpc</groupId>
             <artifactId>xmlrpc-client</artifactId>
             <version>${xmlrpc.client.version}</version>
-        </dependency>
-        <dependency>
-       	    <groupId>com.atlassian.jira</groupId>
-            <artifactId>jira-rest-java-client-api</artifactId>
-            <version>${jira.client.version}</version>
         </dependency>
         <dependency>
        	    <groupId>com.atlassian.jira</groupId>


### PR DESCRIPTION
follow up an [old question](https://answers.atlassian.com/questions/38528888/answers/39228416/comments/39241115) I met when I first upgraded JRJC to 4.0.0 from 3.0.0.

In short, 
1. upgrade fugue.version to a newer version 
2. 

> api is not necessary, because it is a dependency of core.