### PR TITLE
add back jira-rest-java-client-api dependency for easy test.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,11 @@
             <version>${xmlrpc.client.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.atlassian.jira</groupId>
+            <artifactId>jira-rest-java-client-api</artifactId>
+            <version>${jira.client.version}</version>
+        </dependency>
+        <dependency>
        	    <groupId>com.atlassian.jira</groupId>
             <artifactId>jira-rest-java-client-core</artifactId>
             <version>${jira.client.version}</version>


### PR DESCRIPTION
https://github.com/jboss-set/aphrodite/pull/93 removed dependency "jira-rest-java-client-api" as suggested in an atlassian question. This leads following exception in my test while it creates Aphrodite instance. although, it's fine to create such instance on server side. I think we should add it back as we need such handy test for Aphrodite functions.
Sorry about the inconvenience

```
Exception in thread "main" java.lang.NoClassDefFoundError: org/slf4j/impl/StaticLoggerBinder
	at org.slf4j.LoggerFactory.getSingleton(LoggerFactory.java:223)
	at org.slf4j.LoggerFactory.bind(LoggerFactory.java:120)
	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:111)
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:269)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:242)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:255)
	at com.atlassian.httpclient.apache.httpcomponents.ApacheAsyncHttpClient.<init>(ApacheAsyncHttpClient.java:92)
	at com.atlassian.httpclient.apache.httpcomponents.ApacheAsyncHttpClient.<init>(ApacheAsyncHttpClient.java:123)
	at com.atlassian.httpclient.apache.httpcomponents.DefaultHttpClientFactory.doCreate(DefaultHttpClientFactory.java:68)
	at com.atlassian.httpclient.apache.httpcomponents.DefaultHttpClientFactory.create(DefaultHttpClientFactory.java:35)
	at com.atlassian.jira.rest.client.internal.async.AsynchronousHttpClientFactory.createClient(AsynchronousHttpClientFactory.java:63)
	at com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory.create(AsynchronousJiraRestClientFactory.java:35)
	at com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory.createWithBasicHttpAuthentication(AsynchronousJiraRestClientFactory.java:42)
	at org.jboss.set.aphrodite.issue.trackers.jira.JiraIssueTracker.init(JiraIssueTracker.java:104)
	at org.jboss.set.aphrodite.issue.trackers.common.AbstractIssueTracker.init(AbstractIssueTracker.java:78)
	at org.jboss.set.aphrodite.Aphrodite.init(Aphrodite.java:153)
	at org.jboss.set.aphrodite.Aphrodite.<init>(Aphrodite.java:131)
	at org.jboss.set.aphrodite.Aphrodite.instance(Aphrodite.java:81)
	at Main.main(Main.java:71)
Caused by: java.lang.ClassNotFoundException: org.slf4j.impl.StaticLoggerBinder
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 19 more
```