### PR TITLE
fix bug that "needinfo" and "requires_doc_text" are mistaken as stream flag.

### DIFF
--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/IssueWrapper.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/IssueWrapper.java
@@ -272,6 +272,8 @@ class IssueWrapper {
 
                     FlagStatus status = FlagStatus.getMatchingFlag((String) flagMap.get(FLAG_STATUS));
                     issueStage.setStatus(flag.get(), status);
+                } else if (name.equals("needinfo") || name.equals("requires_doc_text")) {
+                    continue;
                 } else { // Else Stream
                     FlagStatus status = FlagStatus.getMatchingFlag((String) flagMap.get(FLAG_STATUS));
                     streams.put(name, status);


### PR DESCRIPTION
If bugzilla flag name does not contain "_ack",  IssueWrapper mistakes it as stream value which is wrong since it could be "needinfo" and "requires_doc_text".