### PR TITLE
Sprint field

### DIFF
--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/IssueWrapper.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/IssueWrapper.java
@@ -125,7 +125,9 @@ class IssueWrapper {
         setIssueComments(issue, jiraIssue);
         setCreationTime(issue, jiraIssue);
         setLastUpdated(issue, jiraIssue);
+        // Set JIRA specific fields
         setPullRequests(issue,jiraIssue);
+        setIssueSprintRelease(issue, jiraIssue);
         return issue;
     }
 
@@ -260,6 +262,31 @@ class IssueWrapper {
             default:
                 return IssueType.getMatchingIssueType(type);
         }
+    }
+
+    private void setIssueSprintRelease(JiraIssue issue, com.atlassian.jira.rest.client.api.domain.Issue jiraIssue) {
+        final IssueField issueField = jiraIssue.getFieldByName("Sprint");
+        if ( issueField != null && issueField.getValue() != null ) {
+            JSONArray fieldValue = (JSONArray) issueField.getValue();
+            if ( fieldValue.length() > 0 )
+                issue.setSprintRelease(extractSprintName(fieldValue));
+        }
+    }
+
+    /*
+     * Horrible hack :( - but no other options apparently
+     * See https://answers.atlassian.com/questions/92681/how-to-get-sprints-using-greenhopper-api
+    */
+    private static final String NAME_FIELD_ATTRIBUTE = "name=";
+    private String extractSprintName(JSONArray fieldValue) {
+        try {
+            String value = (String) fieldValue.get(0);
+            value = value.substring(value.indexOf(NAME_FIELD_ATTRIBUTE));
+            return value.substring(NAME_FIELD_ATTRIBUTE.length(), value.indexOf(','));
+        } catch ( JSONException e) {
+            return "";
+        }
+
     }
 
     private void setIssueStream(Issue issue, com.atlassian.jira.rest.client.api.domain.Issue jiraIssue) {

--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssue.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssue.java
@@ -14,6 +14,8 @@ public class JiraIssue extends Issue {
 
     private List<URL> pullRequests = new ArrayList<URL>();
 
+    private String sprintRelease = "";
+
     public JiraIssue(URL url, TrackerType type) {
         super(url, type);
         if ( ! type.equals(TrackerType.JIRA) )
@@ -26,6 +28,14 @@ public class JiraIssue extends Issue {
 
     public void setPullRequests(List<URL> pullRequests) {
         this.pullRequests = pullRequests;
+    }
+
+    public String getSprintRelease() {
+        return sprintRelease;
+    }
+
+    public void setSprintRelease(String sprintRelease) {
+        this.sprintRelease = sprintRelease;
     }
 
 }


### PR DESCRIPTION
In order to be able to implements checks based on the Sprint field with Bugclerk (see https://github.com/jboss-set/bug-clerk/issues/44 and https://github.com/jboss-set/bug-clerk/issues/40), I've added support for the associate JIRA field (afaik no such field for BZ, so it ends up in the JIRA specific issue).

However, I stumble upon some no sense (as you can see with the method called "extractSprintName"). So why did I came to do that. At first glance, indeed, it looked like the Java client for JIRA Aphrodite uses was able to retrieve a JSON element containing all the information for this custom field - see the result of toString() (with Eclipse debugger):

["com.atlassian.greenhopper.service.sprint.Sprint@74683e65[id=4786,rapidViewId=3466,state=CLOSED,name=EAP 7.0.1,startDate=2016-05-11T02:48:59.548-04:00,endDate=2016-07-20T02:48:00.000-04:00,completeDate=2016-07-26T03:41:18.239-04:00,sequence=4786]"]

However, we do NOT have the com.atlassian.greenhopper.service.sprint.Sprint in our classpath, neither was able to (quickly) finds a jar I could add to it to get this class definiton. However, as the value return is a JSON array (class org.codehaus.jettison.json.JSONArray), I tried to simply decode the JSON manually (not ideal, but arguably maybe better than adding a new dep).

However it turns out that his JSON Array only contains a string matching the content above (not a JSON string that one could parse).

This was confirmed by the answer on this FAQ from Atlassian: https://answers.atlassian.com/questions/92681/how-to-get-sprints-using-greenhopper-api

So, I ended up parsing the result of the toString() method to extract the Sprint name :(

Needless to say that if anybody has a better idea I'll be quite happy to have this enhanced/removed...