### PR TITLE
Revert PR89

### DIFF
--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/IssueWrapper.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/IssueWrapper.java
@@ -110,10 +110,9 @@ class IssueWrapper {
         String type = (String) bug.get(ISSUE_TYPE);
         issue.setType(IssueType.getMatchingIssueType(type));
 
-        String version = (String) ((Object[]) bug.get(VERSION))[0];
-        List<Release> releases = new ArrayList<>();
-        releases.add(new Release((String) bug.get(TARGET_RELEASE), (String) bug.get(TARGET_MILESTONE)));
-        issue.setReleases(releases);
+        setAffectedVersions(issue, (Object[]) (bug.get(VERSION)) );
+        setReleases(issue, bug);
+
         List<URL> dependsOn = getListOfURlsFromIds(bug, baseURL, DEPENDS_ON);
         dependsOn.addAll(getListOfExternalURLsFromIds(bug, EXTERNAL_URL));
         issue.setDependsOn(dependsOn);
@@ -210,7 +209,7 @@ class IssueWrapper {
         List<Release> releases = issue.getReleases();
         if (!releases.isEmpty()) {
             Release release = releases.get(0);
-            release.getVersion().ifPresent(version -> params.put(TARGET_RELEASE, version));
+            release.getVersion().ifPresent(version -> params.put(VERSION, version));
             release.getMilestone().ifPresent(milestone -> params.put(TARGET_MILESTONE, milestone));
 
             if (releases.size() > 1) {

--- a/src/test/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BZIssueWrapperTest.java
+++ b/src/test/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BZIssueWrapperTest.java
@@ -153,8 +153,7 @@ public class BZIssueWrapperTest {
         result.put(BugzillaFields.COMPONENT, new String[] { "CLI" });
         result.put(BugzillaFields.PRODUCT, "EAP");
         result.put(BugzillaFields.ISSUE_TYPE, IssueType.BUG.get());
-        result.put(BugzillaFields.VERSION, new String[] { "6.4.5" });
-        result.put(BugzillaFields.TARGET_RELEASE, "6.4.5");
+        result.put(BugzillaFields.VERSION, new String[] { "6.4.4" });
         result.put(BugzillaFields.TARGET_MILESTONE, "---");
         result.put(BugzillaFields.DEPENDS_ON, new String[] {
                 "1111112",
@@ -196,7 +195,7 @@ public class BZIssueWrapperTest {
         result.setType(IssueType.BUG);
 
         List<Release> releases = new ArrayList<>();
-        releases.add(new Release("6.4.5", "---"));
+        releases.add(new Release("6.4.4", "---"));
         result.setReleases(releases);
 
         result.setDependsOn(Arrays.asList(
@@ -233,8 +232,11 @@ public class BZIssueWrapperTest {
         assertEquals("bug product mismatch", expected.get(BugzillaFields.PRODUCT), other.get(BugzillaFields.PRODUCT));
         assertEquals("bug type mismatch", expected.get(BugzillaFields.ISSUE_TYPE), other.get(BugzillaFields.ISSUE_TYPE));
 
-        assertEquals("bug release mismatch", expected.get(BugzillaFields.TARGET_RELEASE),
-                other.get(BugzillaFields.TARGET_RELEASE));
+        Object expectedVersions[] = (Object[]) expected.get(BugzillaFields.VERSION);
+        assertEquals("bug version mismatch", expectedVersions[0], other.get(BugzillaFields.VERSION));
+
+        assertEquals("bug milestone mismatch", expected.get(BugzillaFields.TARGET_MILESTONE),
+                other.get(BugzillaFields.TARGET_MILESTONE));
 
         String expectedDependsOn[] = (String[]) expected.get(BugzillaFields.DEPENDS_ON);
 

--- a/src/test/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssueWrapperTest.java
+++ b/src/test/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssueWrapperTest.java
@@ -193,7 +193,7 @@ public class JiraIssueWrapperTest {
         when(targetField.getValue()).thenReturn(targetObject);
 
         Version versionMock = mock(Version.class);
-        when(versionMock.getName()).thenReturn("6.4.5");
+        when(versionMock.getName()).thenReturn("6.4.4");
         when(jiraIssue01.getFixVersions()).thenReturn(Collections.singletonList(versionMock));
 
         IssueType issueTypeMock = mock(IssueType.class);
@@ -222,7 +222,7 @@ public class JiraIssueWrapperTest {
         result.setType(org.jboss.set.aphrodite.domain.IssueType.BUG);
 
         List<Release> releases = new ArrayList<>();
-        releases.add(new Release("6.4.5"));
+        releases.add(new Release("6.4.4"));
         result.setReleases(releases);
 
         result.setDependsOn(Collections.emptyList());


### PR DESCRIPTION
PR89 was badly merged and superseed by a previous one - it needs to be revert as it is currently breaking the BZ wrapper and does not bring any value (anymore)