### PR TITLE
Add support for JIRA resolution field

### DIFF
--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/IssueWrapper.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/IssueWrapper.java
@@ -126,15 +126,29 @@ class IssueWrapper {
         setCreationTime(issue, jiraIssue);
         setLastUpdated(issue, jiraIssue);
         // Set JIRA specific fields
-        setPullRequests(issue,jiraIssue);
+        setPullRequests(issue, jiraIssue);
         setIssueSprintRelease(issue, jiraIssue);
+        setResolution(issue, jiraIssue);
         return issue;
     }
 
+    private void setResolution(JiraIssue issue, com.atlassian.jira.rest.client.api.domain.Issue jiraIssue) {
+        if (jiraIssue.getResolution() != null && !"".equals(jiraIssue.getResolution())) {
+            if (!JiraIssueResolution.hasId(jiraIssue.getResolution().getId())) {
+                String msg = String.format("Could not convert issue resolution: %1$s (%2$s) for issue: %3$s", jiraIssue
+                        .getResolution().getName(), jiraIssue.getResolution().getId(), jiraIssue.getKey());
+                Utils.logWarnMessage(LOG, msg);
+            } else
+                issue.setResolution(JiraIssueResolution.getById(jiraIssue.getResolution().getId()));
+        } else
+            issue.setResolution(JiraIssueResolution.UNRESOLVED);
+
+    }
+
     private static void setIssueAffectedVersions(JiraIssue issue, com.atlassian.jira.rest.client.api.domain.Issue jiraIssue) {
-        if ( jiraIssue.getAffectedVersions() != null ) {
+        if (jiraIssue.getAffectedVersions() != null) {
             List<String> affectedVersion = new ArrayList<String>(0);
-            for ( Version version : jiraIssue.getAffectedVersions() )
+            for (Version version : jiraIssue.getAffectedVersions())
                 affectedVersion.add(version.getName());
             issue.setAffectedVersions(affectedVersion);
         }

--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssue.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssue.java
@@ -16,9 +16,19 @@ public class JiraIssue extends Issue {
 
     private String sprintRelease = "";
 
+    private JiraIssueResolution resolution;
+
+    public JiraIssueResolution getResolution() {
+        return resolution;
+    }
+
+    public void setResolution(JiraIssueResolution resolution) {
+        this.resolution = resolution;
+    }
+
     public JiraIssue(URL url, TrackerType type) {
         super(url, type);
-        if ( ! type.equals(TrackerType.JIRA) )
+        if (!type.equals(TrackerType.JIRA))
             throw new IllegalStateException("Can't instantiate if issue is not of JIRA type");
     }
 

--- a/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssueResolution.java
+++ b/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssueResolution.java
@@ -1,0 +1,43 @@
+package org.jboss.set.aphrodite.issue.trackers.jira;
+
+public enum JiraIssueResolution {
+
+    DONE(1,"DONE"), REJECTED(2, "REJECTED"), DUPLICATE_ISSUE(3,"DUPLICATE ISSUE"), INCOMPLETE_DESCRIPTION(4,"INCOMPLETE DESCRIPTION"), CANNOT_REPRODUCE_BUG(
+            5, "CANNOT REPRODUCE BUG"), PARTIALLY_COMPLETED(7,"PARTIALLY COMPLETED"), DEFERRED(8,"DEFERRED"), WONTFIX(9,"WON'T FIX"), OUT_OF_DATE(10,
+            "OUT OF DATE"), MIGRATED(11,"MIGRATED TO ANOTHER ITS"), RESOLVED_AT_APACHE(12, "RESOLVED AT APACHE"), UNRESOLVED(
+            0,"UNRESOLVED"), WONTDO(10000, "WON'T DO"), CANNOT_REPRODUCE(10002, "CANNOT REPRODUCE"), DUPLICATE(10200,"DUPLICATE");
+
+    private long id;
+    private String label;
+
+    private JiraIssueResolution(final long id, final String label) {
+        this.id = id;
+        this.label = label;
+    }
+
+    @Override
+    public String toString() {
+        return label;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public static boolean hasId(long id ) {
+        for (JiraIssueResolution resolution: JiraIssueResolution.values() ) {
+            if ( resolution.getId() == id )
+                return true;
+        }
+        return false;
+    }
+
+    public static JiraIssueResolution getById(long id) {
+        for (JiraIssueResolution resolution : JiraIssueResolution.values())
+            if (resolution.getId() == id)
+                return resolution;
+
+        throw new IllegalArgumentException("No resolution associated with id:" + id);
+    }
+
+}


### PR DESCRIPTION
BZ has no Resolution field but JIRA does, so those changes add support for that in the JIRA instance. 

Please note that this change will allow BugClerk to filter out (ignore) issue which has been set to a Resolved state (or rejected or cannot_reproduce, and so on).