### PR TITLE
refactor for pull requst model and patch model

### DIFF
--- a/common/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
@@ -52,8 +52,8 @@ import org.jboss.set.aphrodite.domain.Comment;
 import org.jboss.set.aphrodite.domain.CommitStatus;
 import org.jboss.set.aphrodite.domain.Issue;
 import org.jboss.set.aphrodite.domain.Label;
-import org.jboss.set.aphrodite.domain.Patch;
-import org.jboss.set.aphrodite.domain.PatchState;
+import org.jboss.set.aphrodite.domain.PullRequest;
+import org.jboss.set.aphrodite.domain.PullRequestState;
 import org.jboss.set.aphrodite.domain.RateLimit;
 import org.jboss.set.aphrodite.domain.Repository;
 import org.jboss.set.aphrodite.domain.SearchCriteria;
@@ -388,19 +388,19 @@ public class Aphrodite implements AutoCloseable {
     }
 
     /**
-     * Retrieve all Issues associated with the provided patch object.
+     * Retrieve all Issues associated with the provided pull request object.
      * Implementations of this method assume that the urls of the related issues are present in the
-     * patch's description field.
+     * pullRequest's description field.
      *
-     * @param patch the <code>Patch</code> object whoms associated Issues should be returned.
+     * @param pullRequest the <code>PullRequest</code> object whoms associated Issues should be returned.
      * @return a list of all <code>Issue</code> objects, or an empty list if no issues can be found.
      */
-    public List<Issue> getIssuesAssociatedWith(Patch patch) {
+    public List<Issue> getIssuesAssociatedWith(PullRequest pullRequest) {
         checkIssueTrackerExists();
-        Objects.requireNonNull(patch, "patch cannot be null");
+        Objects.requireNonNull(pullRequest, "pull request cannot be null");
 
         return issueTrackers.values().stream()
-                .map(service -> service.getIssuesAssociatedWith(patch))
+                .map(service -> service.getIssuesAssociatedWith(pullRequest))
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
     }
@@ -425,60 +425,60 @@ public class Aphrodite implements AutoCloseable {
     }
 
     /**
-     * Retrieve all Patches associated with the provided <code>Issue</code> object
+     * Retrieve all pull requests associated with the provided <code>Issue</code> object
      *
-     * @param issue the <code>Issue</code> object whose associated Patches should be returned.
-     * @return a list of all <code>Patch</code> objects, or an empty list if no patches can be found.
-     * @throws a <code>NotFoundException</code>, if an exception is encountered when trying to retrieve patches from a RepositoryService
+     * @param issue the <code>Issue</code> object whose associated pull requests should be returned.
+     * @return a list of all <code>PullRequest</code> objects, or an empty list if no pull request can be found.
+     * @throws a <code>NotFoundException</code>, if an exception is encountered when trying to retrieve pull requests from a RepositoryService
      */
-//    public List<Patch> getPatchesAssociatedWith(Issue issue) throws NotFoundException {
+//    public List<PullRequest> getPullRequestAssociatedWith(Issue issue) throws NotFoundException {
 //        checkRepositoryServiceExists();
 //        Objects.requireNonNull(issue, "issue cannot be null");
 //
-//        List<Patch> patches = new ArrayList<>();
+//        List<PullRequest> pullRequests = new ArrayList<>();
 //        for (RepositoryService repositoryService : repositories) {
-//            patches.addAll(repositoryService.getPatchesAssociatedWith(issue));
+//            pullRequests.addAll(repositoryService.getPullRequestsAssociatedWith(issue));
 //        }
-//        return patches;
+//        return pullRequests;
 //    }
 
     /**
-     * Retrieve all Patches associated with the provided <code>Repository</code> object, which have a
-     * state that matches the provided <code>PatchState</code> object.
+     * Retrieve all PullRequests associated with the provided <code>Repository</code> object, which have a
+     * state that matches the provided <code>PullRequestState</code> object.
      *
-     * @param repository the <code>Repository</code> object whose associated Patches should be returned.
-     * @param state the <code>PatchState</code> which the returned <code>Patch</code> objects must have.
-     * @return a list of all matching <code>Patch</code> objects, or an empty list if no patches can be found.
-     * @throws a <code>NotFoundException</code>, if an exception is encountered when trying to retrieve patches from a RepositoryService
+     * @param repository the <code>Repository</code> object whose associated PullRequests should be returned.
+     * @param state the <code>PullRequestState</code> which the returned <code>PullRequest</code> objects must have.
+     * @return a list of all matching <code>PullRequest</code> objects, or an empty list if no pullRequests can be found.
+     * @throws a <code>NotFoundException</code>, if an exception is encountered when trying to retrieve pullRequests from a RepositoryService
      */
-    public List<Patch> getPatchesByState(Repository repository, PatchState state) throws NotFoundException {
+    public List<PullRequest> getPullRequestsByState(Repository repository, PullRequestState state) throws NotFoundException {
         checkRepositoryServiceExists();
         Objects.requireNonNull(repository, "repository cannot be null");
         Objects.requireNonNull(state, "state cannot be null");
 
         for (RepositoryService repositoryService : repositories) {
             if (repositoryService.urlExists(repository.getURL()))
-                return repositoryService.getPatchesByState(repository, state);
+                return repositoryService.getPullRequestsByState(repository, state);
         }
         return new ArrayList<>();
     }
 
     /**
-     * Get the <code>Patch</code> located at the provided <code>URL</code>.
+     * Get the <code>PullRequest</code> located at the provided <code>URL</code>.
      *
-     * @param url the <code>URL</code> of the patch to be retrieved.
-     * @return the <code>Patch</code> object.
-     * @throws NotFoundException if a <code>Patch</code> cannot be found at the provided base url.
+     * @param url the <code>URL</code> of the pullRequest to be retrieved.
+     * @return the <code>PullRequest</code> object.
+     * @throws NotFoundException if a <code>PullRequest</code> cannot be found at the provided base url.
      */
-    public Patch getPatch(URL url) throws NotFoundException {
+    public PullRequest getPullRequest(URL url) throws NotFoundException {
         checkRepositoryServiceExists();
         Objects.requireNonNull(url, "url cannot be null");
 
         for (RepositoryService repositoryService : repositories) {
             if (repositoryService.repositoryAccessable(url) && repositoryService.urlExists(url))
-                return repositoryService.getPatch(url);
+                return repositoryService.getPullRequest(url);
         }
-        throw new NotFoundException("No patch found which corresponds to url: " + url);
+        throw new NotFoundException("No pull request found which corresponds to url: " + url);
     }
 
     public Map<RepositoryType, RateLimit> getRateLimits() throws NotFoundException {
@@ -492,7 +492,7 @@ public class Aphrodite implements AutoCloseable {
     }
 
     /**
-     * Retrieve all labels associated with the provided <code>Patch</code> in <code>Repository</code> object.
+     * Retrieve all labels associated with the provided <code>PullRequest</code> in <code>Repository</code> object.
      * @param repository the <code>Repository<code> object whose associated labels should be returned.
      * @return a list of all matching <code>Label<code> objects, or an empty list if no labels can be found.
      * @throws a <code>NotFoundException</code> if an error is encountered when trying to retrieve labels from a RepositoryService
@@ -509,25 +509,25 @@ public class Aphrodite implements AutoCloseable {
     }
 
     /**
-     * Retrieve all labels associated with the provided <code>Patch</code> object.
-     * @param patch the <code>Patch<code> object whose associated labels should be returned.
-     * @return a list of all matching <code>Label<code> objects, or an empty list if no patches can be found.
+     * Retrieve all labels associated with the provided <code>PullRequest</code> object.
+     * @param pull request the <code>PullRequest<code> object whose associated labels should be returned.
+     * @return a list of all matching <code>Label<code> objects, or an empty list if no pull request can be found.
      * @throws a <code>NotFoundException</code> if an error is encountered when trying to retrieve labels from a RepositoryService
      */
-    public List<Label> getLabelsFromPatch(Patch patch) throws NotFoundException {
+    public List<Label> getLabelsFromPullRequest(PullRequest pullRequest) throws NotFoundException {
         checkRepositoryServiceExists();
-        Objects.requireNonNull(patch, "patch cannot be null");
+        Objects.requireNonNull(pullRequest, "pull request cannot be null");
 
         for (RepositoryService repositoryService : repositories) {
-            if (repositoryService.urlExists(patch.getURL()))
-                return repositoryService.getLabelsFromPatch(patch);
+            if (repositoryService.urlExists(pullRequest.getURL()))
+                return repositoryService.getLabelsFromPullRequest(pullRequest);
         }
         return new ArrayList<>();
     }
 
     /**
      * Discover if the user logged into a <code>RepositoryService</code> has the correct permissions to apply/remove
-     * labels to patches in the provided <code>Repository</code>
+     * labels to pull request in the provided <code>Repository</code>
      *
      * @param repository the <code>Repository</code> whose permissions are to be checked
      * @return true if the user has permission, otherwise false.
@@ -545,117 +545,117 @@ public class Aphrodite implements AutoCloseable {
     }
 
     /**
-     * Set the labels for the provided <code>Patch</code> object.
-     * @param patch the <code>Patch</code> object whose will be set.
-     * @param labels the <code>Label</code> apply to the <code>Patch</code>
-     * @throws NotFoundException if the <code>Label</code> can not be found in the provided <code>Patch</code>
+     * Set the labels for the provided <code>PullRequest</code> object.
+     * @param pullRequest the <code>PullRequest</code> object whose will be set.
+     * @param labels the <code>Label</code> apply to the <code>PullRequest</code>
+     * @throws NotFoundException if the <code>Label</code> can not be found in the provided <code>PullRequest</code>
      * @throws AphroditeException if add the <code>Label<code> is not consistent with get labels
      */
-    public void setLabelsToPatch(Patch patch, List<Label> labels) throws NotFoundException, AphroditeException {
+    public void setLabelsToPullRequest(PullRequest pullRequest, List<Label> labels) throws NotFoundException, AphroditeException {
         checkRepositoryServiceExists();
-        Objects.requireNonNull(patch, "patch cannot be null");
+        Objects.requireNonNull(pullRequest, "pull request cannot be null");
         Objects.requireNonNull(labels, "labels cannot be null");
 
         for (RepositoryService repositoryService : repositories) {
-            if (repositoryService.urlExists(patch.getURL()))
-                repositoryService.setLabelsToPatch(patch, labels);
+            if (repositoryService.urlExists(pullRequest.getURL()))
+                repositoryService.setLabelsToPullRequest(pullRequest, labels);
         }
     }
 
     /**
-     * Delete a label from the provided <code>Patch</code> object.
-     * @param patch the <code>Patch</code> whose label will be removed.
+     * Delete a label from the provided <code>PullRequest</code> object.
+     * @param pullRequest the <code>PullRequest</code> whose label will be removed.
      * @param name the <code>Label</code> name will be removed.
-     * @throws NotFoundException if the <code>Label</code> name can not be found in the provided <code>Patch</code>, or an
+     * @throws NotFoundException if the <code>Label</code> name can not be found in the provided <code>PullRequest</code>, or an
      * exception occurs when contacting the RepositoryService
      */
-    public void removeLabelFromPatch(Patch patch, String name) throws NotFoundException {
+    public void removeLabelFromPullRequest(PullRequest pullRequest, String name) throws NotFoundException {
         checkRepositoryServiceExists();
-        Objects.requireNonNull(patch, "patch cannot be null");
+        Objects.requireNonNull(pullRequest, "pull request cannot be null");
         Objects.requireNonNull(name, "labelname cannot be null");
 
         for (RepositoryService repositoryService : repositories) {
-            if (repositoryService.urlExists(patch.getURL()))
-                repositoryService.removeLabelFromPatch(patch, name);
+            if (repositoryService.urlExists(pullRequest.getURL()))
+                repositoryService.removeLabelFromPullRequest(pullRequest, name);
         }
     }
 
     /**
-     * Add a <code>Comment</code> to the specified <code>Patch</code> object, and propagate the changes
+     * Add a <code>Comment</code> to the specified <code>PullRequest</code> object, and propagate the changes
      * to the remote repository.
      *
-     * @param patch the <code>Patch</code> on which the comment will be made.
+     * @param pullRequest the <code>PullRequest</code> on which the comment will be made.
      * @param comment the new <code>Comment</code>.
-     * @throws NotFoundException if the <code>Patch</code> cannot be found at the remote repository.
+     * @throws NotFoundException if the <code>PullRequest</code> cannot be found at the remote repository.
      */
-    public void addCommentToPatch(Patch patch, String comment) throws NotFoundException {
+    public void addCommentToPullRequest(PullRequest pullRequest, String comment) throws NotFoundException {
         checkRepositoryServiceExists();
-        Objects.requireNonNull(patch, "patch cannot be null");
+        Objects.requireNonNull(pullRequest, "pull request cannot be null");
         Objects.requireNonNull(comment, "comment cannot be null");
 
         for (RepositoryService repositoryService : repositories) {
-            if (repositoryService.urlExists(patch.getURL())) {
-                repositoryService.addCommentToPatch(patch, comment);
+            if (repositoryService.urlExists(pullRequest.getURL())) {
+                repositoryService.addCommentToPullRequest(pullRequest, comment);
                 return;
             }
         }
-        throw new NotFoundException("No patch found which corresponds to patch.");
+        throw new NotFoundException("No pull request found which corresponds to pull request.");
     }
 
     /**
-     * Attach a label to the specified patch.  Note the label must already exist at remote repository,
+     * Attach a label to the specified pull request.  Note the label must already exist at remote repository,
      * otherwise it will not be applied. If the specified label is already
-     * associated with the provided patch then no further action is taken.
+     * associated with the provided pull request then no further action is taken.
      *
-     * @param patch the <code>Patch</code> to which the label will be applied.
+     * @param pullRequest the <code>PullRequest</code> to which the label will be applied.
      * @param labelName the name of the label to be applied.
-     * @throws a <code>NotFoundException</code> if the <code>Patch</code> cannot be found, or the labelName does not exist.
+     * @throws a <code>NotFoundException</code> if the <code>PullRequest</code> cannot be found, or the labelName does not exist.
      */
-    public void addLabelToPatch(Patch patch, String labelName) throws NotFoundException {
+    public void addLabelToPullRequest(PullRequest pullRequest, String labelName) throws NotFoundException {
         checkRepositoryServiceExists();
-        Objects.requireNonNull(patch, "patch cannot be null");
+        Objects.requireNonNull(pullRequest, "pull request cannot be null");
         Objects.requireNonNull(labelName, "labelName cannot be null");
 
         for (RepositoryService repositoryService : repositories) {
-            if (repositoryService.urlExists(patch.getURL()))
-                repositoryService.addLabelToPatch(patch, labelName);
+            if (repositoryService.urlExists(pullRequest.getURL()))
+                repositoryService.addLabelToPullRequest(pullRequest, labelName);
         }
     }
 
     /**
-     * Retrieve all <code>Patch</code> objects related to the supplied patch. A patch is related if its URL is referenced in the
-     * provided patch object. Note, this method fails silently if a patch cannot be retrieved from a URL, with the error message
+     * Retrieve all <code>PullRequest</code> objects related to the supplied pull request. A pull request is related if its URL is referenced in the
+     * provided pull request object. Note, this method fails silently if a pull request cannot be retrieved from a URL, with the error message
      * simply logged.
      *
-     * @param patch the <code>Patch</code> object to be queried against
-     * @return a list of Patch objects that are related to the supplied patch object
+     * @param pull request the <code>PullRequest</code> object to be queried against
+     * @return a list of PullRequest objects that are related to the supplied pull request object
      */
-    public List<Patch> findPatchesRelatedTo(Patch patch) {
+    public List<PullRequest> findPullRequestsRelatedTo(PullRequest pullRequest) {
         checkRepositoryServiceExists();
-        Objects.requireNonNull(patch, "patch cannot be null");
+        Objects.requireNonNull(pullRequest, "pull request cannot be null");
 
         return repositories.stream()
-                .filter(service -> service.urlExists(patch.getURL()))
-                .flatMap(service -> service.findPatchesRelatedTo(patch).stream())
+                .filter(service -> service.urlExists(pullRequest.getURL()))
+                .flatMap(service -> service.findPullRequestsRelatedTo(pullRequest).stream())
                 .collect(Collectors.toList());
     }
 
     /**
-     * Retrieve the current CI status of the latest commit associated with a given patch.
+     * Retrieve the current CI status of the latest commit associated with a given pull request.
      *
-     * @param patch the <code>Patch</code> object whose status is to be queried
-     * @return the CI status of the latest commit associated with the given patch
-     * @throws NotFoundException if no commit status can be found for the provided patch
+     * @param pullRequest the <code>PullRequest</code> object whose status is to be queried
+     * @return the CI status of the latest commit associated with the given pull request
+     * @throws NotFoundException if no commit status can be found for the provided pull request
      */
-    public CommitStatus getCommitStatusFromPatch(Patch patch) throws NotFoundException {
+    public CommitStatus getCommitStatusFromPullRequest(PullRequest pullRequest) throws NotFoundException {
         checkRepositoryServiceExists();
-        Objects.requireNonNull(patch, "patch cannot be null");
+        Objects.requireNonNull(pullRequest, "pull request cannot be null");
 
         for (RepositoryService repositoryService : repositories) {
-            if (repositoryService.urlExists(patch.getURL()))
-                return repositoryService.getCommitStatusFromPatch(patch);
+            if (repositoryService.urlExists(pullRequest.getURL()))
+                return repositoryService.getCommitStatusFromPullRequest(pullRequest);
         }
-        throw new NotFoundException("No commit status found for patch:" + patch.getURL());
+        throw new NotFoundException("No commit status found for pull request:" + pullRequest.getURL());
     }
 
     /**

--- a/common/src/main/java/org/jboss/set/aphrodite/issue/trackers/common/AbstractIssueTracker.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/issue/trackers/common/AbstractIssueTracker.java
@@ -29,7 +29,7 @@ import org.jboss.set.aphrodite.config.IssueTrackerConfig;
 import org.jboss.set.aphrodite.config.TrackerType;
 import org.jboss.set.aphrodite.domain.Comment;
 import org.jboss.set.aphrodite.domain.Issue;
-import org.jboss.set.aphrodite.domain.Patch;
+import org.jboss.set.aphrodite.domain.PullRequest;
 import org.jboss.set.aphrodite.spi.IssueTrackerService;
 import org.jboss.set.aphrodite.spi.NotFoundException;
 
@@ -100,9 +100,9 @@ public abstract class AbstractIssueTracker implements IssueTrackerService {
     }
 
     @Override
-    public List<Issue> getIssuesAssociatedWith(Patch patch) {
+    public List<Issue> getIssuesAssociatedWith(PullRequest pullRequest) {
         List<Issue> issues = new ArrayList<>();
-        Matcher m = URL_REGEX.matcher(patch.getTitle() + patch.getBody());
+        Matcher m = URL_REGEX.matcher(pullRequest.getTitle() + pullRequest.getBody());
         while (m.find()) {
             String link = m.group();
             try {

--- a/common/src/main/java/org/jboss/set/aphrodite/repository/services/common/AbstractRepositoryService.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/repository/services/common/AbstractRepositoryService.java
@@ -27,8 +27,8 @@ import org.jboss.set.aphrodite.common.Utils;
 import org.jboss.set.aphrodite.config.AphroditeConfig;
 import org.jboss.set.aphrodite.config.RepositoryConfig;
 import org.jboss.set.aphrodite.domain.Issue;
-import org.jboss.set.aphrodite.domain.Patch;
-import org.jboss.set.aphrodite.domain.PatchState;
+import org.jboss.set.aphrodite.domain.PullRequest;
+import org.jboss.set.aphrodite.domain.PullRequestState;
 import org.jboss.set.aphrodite.domain.RateLimit;
 import org.jboss.set.aphrodite.domain.Repository;
 import org.jboss.set.aphrodite.spi.NotFoundException;
@@ -92,17 +92,17 @@ public abstract class AbstractRepositoryService implements RepositoryService {
     }
 
     @Override
-    public Patch getPatch(URL url) throws NotFoundException {
+    public PullRequest getPullRequest(URL url) throws NotFoundException {
         throw new UnsupportedOperationException("Not yet implemented.");
     }
 
     @Override
-    public List<Patch> getPatchesAssociatedWith(Issue issue) throws NotFoundException {
+    public List<PullRequest> getPullRequestsAssociatedWith(Issue issue) throws NotFoundException {
         throw new UnsupportedOperationException("Not yet implemented.");
     }
 
     @Override
-    public List<Patch> getPatchesByState(Repository repository, PatchState state) throws NotFoundException {
+    public List<PullRequest> getPullRequestsByState(Repository repository, PullRequestState state) throws NotFoundException {
         throw new UnsupportedOperationException("Not yet implemented.");
     }
 
@@ -112,7 +112,7 @@ public abstract class AbstractRepositoryService implements RepositoryService {
     }
 
     @Override
-    public void addCommentToPatch(Patch patch, String comment) throws NotFoundException {
+    public void addCommentToPullRequest(PullRequest pullRequest, String comment) throws NotFoundException {
         throw new UnsupportedOperationException("Not yet implemented.");
     }
 

--- a/common/src/main/java/org/jboss/set/aphrodite/spi/IssueTrackerService.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/spi/IssueTrackerService.java
@@ -26,7 +26,7 @@ import org.jboss.set.aphrodite.config.AphroditeConfig;
 import org.jboss.set.aphrodite.config.IssueTrackerConfig;
 import org.jboss.set.aphrodite.domain.Comment;
 import org.jboss.set.aphrodite.domain.Issue;
-import org.jboss.set.aphrodite.domain.Patch;
+import org.jboss.set.aphrodite.domain.PullRequest;
 import org.jboss.set.aphrodite.domain.SearchCriteria;
 import org.jboss.set.aphrodite.issue.trackers.common.AbstractIssueTracker;
 
@@ -73,14 +73,14 @@ public interface IssueTrackerService {
     String getTrackerID();
 
     /**
-     * Retrieve all Issues associated with the provided patch object.
+     * Retrieve all Issues associated with the provided pullRequest object.
      * Implementations of this method assume that the urls of the related issues are present in the
-     * patch's description field.
+     * pullRequest's description field.
      *
-     * @param patch the <code>Patch</code> object whoms associated Issues should be returned.
+     * @param pullRequest the <code>PullRequest</code> object whoms associated Issues should be returned.
      * @return a list of all <code>Issue</code> objects, or an empty list if no issues can be found.
      */
-    List<Issue> getIssuesAssociatedWith(Patch patch);
+    List<Issue> getIssuesAssociatedWith(PullRequest pullRequest);
 
     /**
      * Retrieve an issue object associated with the given <code>URL</code>.

--- a/common/src/main/java/org/jboss/set/aphrodite/spi/RepositoryService.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/spi/RepositoryService.java
@@ -30,8 +30,8 @@ import org.jboss.set.aphrodite.config.RepositoryConfig;
 import org.jboss.set.aphrodite.domain.CommitStatus;
 import org.jboss.set.aphrodite.domain.Issue;
 import org.jboss.set.aphrodite.domain.Label;
-import org.jboss.set.aphrodite.domain.Patch;
-import org.jboss.set.aphrodite.domain.PatchState;
+import org.jboss.set.aphrodite.domain.PullRequest;
+import org.jboss.set.aphrodite.domain.PullRequestState;
 import org.jboss.set.aphrodite.domain.RateLimit;
 import org.jboss.set.aphrodite.domain.Repository;
 import org.jboss.set.aphrodite.repository.services.common.RepositoryType;
@@ -84,36 +84,36 @@ public interface RepositoryService {
     Repository getRepository(URL url) throws NotFoundException;
 
     /**
-     * Get the <code>Patch</code> located at the provided <code>URL</code>.
+     * Get the <code>PullRequest</code> located at the provided <code>URL</code>.
      *
-     * @param url the <code>URL</code> of the patch to be retrieved.
-     * @return the <code>Patch</code> object.
-     * @throws NotFoundException if a <code>Patch</code> cannot be found at the provided base url.
+     * @param url the <code>URL</code> of the pull request to be retrieved.
+     * @return the <code>PullRequest</code> object.
+     * @throws NotFoundException if a <code>PullRequest</code> cannot be found at the provided base url.
      */
-    Patch getPatch(URL url) throws NotFoundException;
+    PullRequest getPullRequest(URL url) throws NotFoundException;
 
     /**
-     * Retrieve all Patches associated with the provided <code>Issue</code> object
+     * Retrieve all pull requests associated with the provided <code>Issue</code> object
      *
-     * @param issue the <code>Issue</code> object whose associated Patches should be returned.
-     * @return a list of all <code>Patch</code> objects, or an empty list if no patches can be found.
+     * @param issue the <code>Issue</code> object whose associated pull requests should be returned.
+     * @return a list of all <code>PullRequest</code> objects, or an empty list if no pull request can be found.
      * @throws NotFoundException if an exception is thrown when searching the RepositoryService.
      */
-    List<Patch> getPatchesAssociatedWith(Issue issue) throws NotFoundException;
+    List<PullRequest> getPullRequestsAssociatedWith(Issue issue) throws NotFoundException;
 
     /**
-     * Retrieve all Patches associated with the provided <code>Repository</code> object, which have a
-     * state that matches the provided <code>PatchState</code> object.
+     * Retrieve all pull requests associated with the provided <code>Repository</code> object, which have a
+     * state that matches the provided <code>PullRequestState</code> object.
      *
-     * @param repository the <code>Repository</code> object whose associated Patches should be returned.
-     * @param state the <code>PatchState</code> which the returned <code>Patch</code> objects must have.
-     * @return a list of all matching <code>Patch</code> objects, or an empty list if no patches can be found.
+     * @param repository the <code>Repository</code> object whose associated pull requests should be returned.
+     * @param state the <code>PullRequestsState</code> which the returned <code>PullRequest</code> objects must have.
+     * @return a list of all matching <code>PullRequest</code> objects, or an empty list if no pull request can be found.
      * @throws NotFoundException if the provided <code>Repository</code> cannot be found at the RepositoryService.
      */
-    List<Patch> getPatchesByState(Repository repository, PatchState state) throws NotFoundException;
+    List<PullRequest> getPullRequestsByState(Repository repository, PullRequestState state) throws NotFoundException;
 
     /**
-     * Retrieve all labels associated with the provided <code>Patch</code> in <code>Repository</code> object.
+     * Retrieve all labels associated with the provided <code>PullRequest</code> in <code>Repository</code> object.
      * @param repository the <code>Repository<code> object whose associated labels should be returned.
      * @return a list of all matching <code>Label<code> objects, or an empty list if no label can be found.
      * @throws NotFoundException if the provided <code>Repository</code> url not consistent with the baseURL.
@@ -121,16 +121,16 @@ public interface RepositoryService {
     List<Label> getLabelsFromRepository(Repository repository) throws NotFoundException;
 
     /**
-     * Retrieve all labels associated with the provided <code>Patch</code> object.
-     * @param patch the <code>Patch<code> object whose associated labels should be returned.
-     * @return a list of all matching <code>Label<code> objects, or an empty list if no patches can be found.
-     * @throws NotFoundException if the provided <code>Patch</code> url not consistent with the baseURL.
+     * Retrieve all labels associated with the provided <code>PullRequest</code> object.
+     * @param pullRequest the <code>PullRequest<code> object whose associated labels should be returned.
+     * @return a list of all matching <code>Label<code> objects, or an empty list if no pull request can be found.
+     * @throws NotFoundException if the provided <code>PullRequest</code> url not consistent with the baseURL.
      */
-    List<Label> getLabelsFromPatch(Patch patch) throws NotFoundException;
+    List<Label> getLabelsFromPullRequest(PullRequest pullRequest) throws NotFoundException;
 
     /**
      * Discover if the user logged into this <code>RepositoryService</code> has the correct permissions to apply/remove
-     * labels to patches in the provided <code>Repository</code>
+     * labels to pull request in the provided <code>Repository</code>
      * @param repository the <code>Repository</code> whose permissions are to be checked
      * @return true if the user has permission, otherwise false.
      * @throws NotFoundException if the specified <code>Repository</code> cannot be found.
@@ -138,59 +138,59 @@ public interface RepositoryService {
     boolean hasModifiableLabels(Repository repository) throws NotFoundException;
 
     /**
-     * Set the labels for the provided <code>Patch</code> object.
-     * @param patch the <code>Patch</code> object whose will be set.
-     * @param labels the <code>Label</code> apply to the <code>Patch</code>
-     * @throws NotFoundException if the <code>Label</code> can not be found in the provided <code>Patch</code>
+     * Set the labels for the provided <code>PullRequest</code> object.
+     * @param pullRequset the <code>PullRequest</code> object whose will be set.
+     * @param labels the <code>Label</code> apply to the <code>PullRequest</code>
+     * @throws NotFoundException if the <code>Label</code> can not be found in the provided <code>PullRequest</code>
      * @throws AphroditeException if add the <code>Label<code> is not consistent with get labels
      */
-    void setLabelsToPatch(Patch patch, List<Label> labels) throws NotFoundException, AphroditeException ;
+    void setLabelsToPullRequest(PullRequest pullRequest, List<Label> labels) throws NotFoundException, AphroditeException ;
 
     /**
-     *Delete a label from the provided <code>Patch</code> object.
-     * @param patch the <code>Patch</code> whose label will be removed.
+     *Delete a label from the provided <code>PullRequest</code> object.
+     * @param pullRequest the <code>PullRequest</code> whose label will be removed.
      * @param name the <code>Label</code> name will be removed.
-     * @throws NotFoundException if the <code>Label</code> name can not be found in the provided <code>Patch</code>
+     * @throws NotFoundException if the <code>Label</code> name can not be found in the provided <code>PullRequest</code>
      */
-    void removeLabelFromPatch(Patch patch, String name) throws NotFoundException;
+    void removeLabelFromPullRequest(PullRequest pullRequest, String name) throws NotFoundException;
 
     /**
-     * Add a <code>Comment</code> to the specified <code>Patch</code> object, and propagate the changes
+     * Add a <code>Comment</code> to the specified <code>PullRequest</code> object, and propagate the changes
      * to the remote repository.
      *
-     * @param patch the <code>Patch</code> on which the comment will be made.
+     * @param pullRequest the <code>PullRequest</code> on which the comment will be made.
      * @param comment the new <code>Comment</code>.
-     * @throws NotFoundException if the <code>Patch</code> cannot be found at the remote repository.
+     * @throws NotFoundException if the <code>PullRequest</code> cannot be found at the remote repository.
      */
-    void addCommentToPatch(Patch patch, String comment) throws NotFoundException;
+    void addCommentToPullRequest(PullRequest pullRequest, String comment) throws NotFoundException;
 
     /**
-     * Attach a label to the specified patch.  Note the label must already exist at remote repository,
+     * Attach a label to the specified pull request.  Note the label must already exist at remote repository,
      * otherwise a <code>NotFoundException</code> will be thrown. If the specified label is already
-     * associated with the provided patch then no further action is taken.
+     * associated with the provided pull request then no further action is taken.
      *
-     * @param patch the <code>Patch</code> to which the label will be applied.
+     * @param pullRequest the <code>PullRequest</code> to which the label will be applied.
      * @param labelName the name of the label to be applied.
      * @throws NotFoundException if the specified labelName has not been defined at the remote repository.
      */
-    void addLabelToPatch(Patch patch, String labelName) throws NotFoundException;
+    void addLabelToPullRequest(PullRequest pullRequest, String labelName) throws NotFoundException;
 
     /**
-     * Find all the patches related to the given patch.
+     * Find all the pull requests related to the given pull request.
      *
-     * @param patch the <code>Patch</code> on which patches related are being searched
-     * @return list of patches related.
+     * @param pullRequest the <code>PullRequest</code> on which pull requests related are being searched
+     * @return list of pull requests related.
      */
-    List<Patch> findPatchesRelatedTo(Patch patch);
+    List<PullRequest> findPullRequestsRelatedTo(PullRequest pullRequest);
 
     /**
-     * Retrieve the current CI status of the latest commit associated with a given patch.
+     * Retrieve the current CI status of the latest commit associated with a given pull request.
      *
-     * @param patch the <code>Patch</code> object whose status is to be queried
-     * @return the CI status of the latest commit associated with the given patch
-     * @throws NotFoundException if no commit status can be found for the provided patch
+     * @param pullRequest the <code>PullRequest</code> object whose status is to be queried
+     * @return the CI status of the latest commit associated with the given pull request
+     * @throws NotFoundException if no commit status can be found for the provided pull request
      */
-    CommitStatus getCommitStatusFromPatch(Patch patch) throws NotFoundException;
+    CommitStatus getCommitStatusFromPullRequest(PullRequest pullRequest) throws NotFoundException;
 
     /**
      * allows to destroy and deallocate resources

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -8,5 +8,12 @@
         <version>0.6.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>jboss-aphrodite-domain</artifactId>
+	<artifactId>jboss-aphrodite-domain</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.jboss.set</groupId>
+			<artifactId>jboss-aphrodite-container</artifactId>
+		</dependency>
+	</dependencies>
 </project>

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/Issue.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/Issue.java
@@ -30,6 +30,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.naming.NameNotFoundException;
+
+import org.jboss.set.aphrodite.container.Container;
+import org.jboss.set.aphrodite.domain.spi.IssueHome;
+import org.jboss.set.aphrodite.domain.spi.PatchHome;
 
 /**
  * Represents an issue in a issue tracker (bugzilla, jira...)
@@ -82,7 +89,13 @@ public class Issue {
     private IssueEstimation estimation;
 
     private List<Comment> comments;
-    
+
+    /*
+     * Modeling possible Patch URL in different PatchType:
+     * 1. Pull Request: Git Pull Request e.g. https://github.com/jbossas/jboss-eap7/pull/1101
+     * 2. Commit: Git or SVN commit e.g. https://github.com/hibernate/hibernate-orm/commit/b053116bb42330971ac1357009b2d8879e21b3f0
+     * 3. File: Attachment Patch file URL
+     */
     private List<Patch> patches;
 
     public Issue(URL url, TrackerType type) {
@@ -100,6 +113,7 @@ public class Issue {
         this.blocks = new ArrayList<>();
         this.comments = new ArrayList<>();
         this.components = new ArrayList<>();
+        this.patches = new ArrayList<>();
     }
 
     public URL getURL() {
@@ -281,6 +295,14 @@ public class Issue {
         this.comments = comments;
     }
 
+    public Stream<Patch> getPatches() throws NameNotFoundException {
+        return Container.instance().lookup(PatchHome.class.getSimpleName(), (PatchHome.class)).findPatchesByIssue(this);
+    }
+
+    public Stream<Issue> getUpstreamReferences() throws NameNotFoundException {
+        return Container.instance().lookup(IssueHome.class.getSimpleName(), (IssueHome.class)).findUpstreamReferences(this);
+    }
+
     @Override
     public String toString() {
         return "Issue{" +
@@ -305,6 +327,7 @@ public class Issue {
                 ", lastUpdated=" + lastUpdated +
                 ", estimation=" + estimation +
                 ", #comments=" + comments.size() +
+                ", #patches=" + patches.size() +
                 "}\n";
     }
 

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/Issue.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/Issue.java
@@ -82,6 +82,8 @@ public class Issue {
     private IssueEstimation estimation;
 
     private List<Comment> comments;
+    
+    private List<Patch> patches;
 
     public Issue(URL url, TrackerType type) {
         if (url == null)

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/Patch.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/Patch.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.set.aphrodite.domain;
+
+import java.net.URL;
+
+/*
+ * Modeling possible Patch in different PatchType:
+ * 1. Pull Request URL: Git Pull Request e.g. https://github.com/jbossas/jboss-eap7/pull/1101
+ *    In Jira, it looks for URL in field 'Git Pull Request'.
+ *    In Bugzilla, it looks for legitimate Git URL in comments.
+ * 2. Commit URL: Git or SVN commit e.g. https://github.com/hibernate/hibernate-orm/commit/b053116bb42330971ac1357009b2d8879e21b3f0
+ *    In Jira, it looks for URL in field 'Git Pull Request'.
+ *    In Bugzilla, it looks for legitimate Git/SVN commit URL in comments.
+ * 3. File URL: Attachment Patch file URL.
+ */
+
+public class Patch {
+
+    private final URL url;
+    private final PatchType patchType;
+    private final PatchState patchState;
+
+    public Patch(URL url, PatchType patchType, PatchState patchState) {
+        this.url = url;
+        this.patchType = patchType;
+        this.patchState = patchState;
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    public PatchType getPatchType() {
+        return patchType;
+    }
+
+    public PatchState getPatchState() {
+        return patchState;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        Patch patch = (Patch) o;
+
+        return url.equals(patch.url);
+
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((url == null) ? 0 : url.hashCode());
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Patch{" + "type=" + patchType + "url=" + url + "patchState=" + patchState + '}';
+    }
+}

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/PatchState.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/PatchState.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.aphrodite.domain;
+
+/**
+ * @author wangc
+ *
+ */
+public enum PatchState {
+    UNDEFINED, OPEN, CLOSED
+}

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/PatchType.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/PatchType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.aphrodite.domain;
+
+public enum PatchType {
+    PULLREQUEST, // Git Pull Request, legitimate patch state OPEN and CLOSED.
+    COMMIT, // Git or SVN commit, legitimate patch state CLOSED.
+    FILE // Attachment File, legitimate patch state UNDEFINED.
+}

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/PullRequest.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/PullRequest.java
@@ -24,17 +24,17 @@ package org.jboss.set.aphrodite.domain;
 
 import java.net.URL;
 
-public class Patch {
+public class PullRequest {
 
     private final String id;
     private final URL url;
     private final Codebase codebase;
-    private PatchState state;
+    private PullRequestState state;
     private String title;
     private String body;
     private Repository repository;
 
-    public Patch(String id, URL url, Repository repository, Codebase codebase, PatchState state, String title, String body) {
+    public PullRequest(String id, URL url, Repository repository, Codebase codebase, PullRequestState state, String title, String body) {
         this.id = id;
         this.url = url;
         this.codebase = codebase;
@@ -44,7 +44,7 @@ public class Patch {
         this.repository = repository;
     }
 
-    public Patch(String id, URL url, Repository repository, Codebase codebase, PatchState state) {
+    public PullRequest(String id, URL url, Repository repository, Codebase codebase, PullRequestState state) {
         this(id, url, repository, codebase, state, null, null);
 
     }
@@ -62,11 +62,11 @@ public class Patch {
         return codebase;
     }
 
-    public PatchState getState() {
+    public PullRequestState getState() {
         return state;
     }
 
-    public void setState(PatchState state) {
+    public void setState(PullRequestState state) {
         this.state = state;
     }
 
@@ -102,9 +102,9 @@ public class Patch {
         if (o == null || getClass() != o.getClass())
             return false;
 
-        Patch patch = (Patch) o;
+        PullRequest pullRequset = (PullRequest) o;
 
-        return url.equals(patch.url);
+        return url.equals(pullRequset.url);
 
     }
 
@@ -118,7 +118,7 @@ public class Patch {
 
     @Override
     public String toString() {
-        return "Patch{" +
+        return "PullRequest{" +
                 "url=" + url +
                 ", state=" + state +
                 ", title='" + title + '\'' +

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/PullRequestState.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/PullRequestState.java
@@ -22,6 +22,6 @@
 
 package org.jboss.set.aphrodite.domain;
 
-public enum PatchState {
+public enum PullRequestState {
     UNDEFINED, OPEN, CLOSED
 }

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/spi/IssueHome.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/spi/IssueHome.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.aphrodite.domain.spi;
+
+import java.util.stream.Stream;
+
+import org.jboss.set.aphrodite.domain.Issue;
+
+/**
+ * @author wangc
+ *
+ */
+public interface IssueHome {
+    /*
+     * Retrieve upstream issues with the given <code>Issue</code>.
+     *
+     * @param issue the input <code>Issue</code> object
+     *
+     * @return a stream of retrieved <code>Issue</code>
+     */
+    Stream<Issue> findUpstreamReferences(Issue issue);
+
+}

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/spi/PatchHome.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/spi/PatchHome.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.aphrodite.domain.spi;
+
+import java.util.stream.Stream;
+
+import org.jboss.set.aphrodite.domain.Issue;
+import org.jboss.set.aphrodite.domain.Patch;
+
+/**
+ * @author wangc
+ *
+ */
+public interface PatchHome {
+    /*
+     * Retrieve Patches with the given <code>Issue</code>.
+     *
+     * @param issue the input <code>Issue</code> object
+     *
+     * @return a stream of retrieved <code>Patch</code>
+     */
+    Stream<Patch> findPatchesByIssue(Issue issue);
+
+}

--- a/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
+++ b/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
@@ -173,7 +173,7 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
     }
 
 //    @Override
-//    public List<PullRequest> getPullRequestesAssociatedWith(Issue issue) throws NotFoundException {
+//    public List<PullRequest> getPullRequestsAssociatedWith(Issue issue) throws NotFoundException {
 //        String trackerId = issue.getTrackerId().orElseThrow(() -> new IllegalArgumentException("Issue.trackerId must be set."));
 //        try {
 //            GitHubGlobalSearchService searchService = new GitHubGlobalSearchService(gitHubClient);
@@ -204,7 +204,7 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
                 issueState = GHIssueState.OPEN;
             }
             List<GHPullRequest> pullRequests = githubRepository.getPullRequests(issueState);
-            return WRAPPER.toAphroditePullRequestes(pullRequests);
+            return WRAPPER.toAphroditePullRequests(pullRequests);
         } catch (IOException e) {
             Utils.logException(LOG, e);
             throw new NotFoundException(e);

--- a/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
+++ b/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
@@ -43,8 +43,8 @@ import org.jboss.set.aphrodite.common.Utils;
 import org.jboss.set.aphrodite.config.RepositoryConfig;
 import org.jboss.set.aphrodite.domain.CommitStatus;
 import org.jboss.set.aphrodite.domain.Label;
-import org.jboss.set.aphrodite.domain.Patch;
-import org.jboss.set.aphrodite.domain.PatchState;
+import org.jboss.set.aphrodite.domain.PullRequest;
+import org.jboss.set.aphrodite.domain.PullRequestState;
 import org.jboss.set.aphrodite.domain.RateLimit;
 import org.jboss.set.aphrodite.domain.Repository;
 import org.jboss.set.aphrodite.repository.services.common.AbstractRepositoryService;
@@ -141,7 +141,7 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
     }
 
     @Override
-    public Patch getPatch(URL url) throws NotFoundException {
+    public PullRequest getPullRequest(URL url) throws NotFoundException {
         checkHost(url);
 
         String[] elements = url.getPath().split("/");
@@ -150,7 +150,7 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
         try {
             GHRepository repository = github.getRepository(repositoryId);
             GHPullRequest pullRequest = repository.getPullRequest(pullId);
-            return WRAPPER.pullRequestToPatch(pullRequest);
+            return WRAPPER.pullRequestToPullRequest(pullRequest);
         } catch (IOException e) {
             Utils.logException(LOG, e);
             throw new NotFoundException(e);
@@ -173,13 +173,13 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
     }
 
 //    @Override
-//    public List<Patch> getPatchesAssociatedWith(Issue issue) throws NotFoundException {
+//    public List<PullRequest> getPullRequestesAssociatedWith(Issue issue) throws NotFoundException {
 //        String trackerId = issue.getTrackerId().orElseThrow(() -> new IllegalArgumentException("Issue.trackerId must be set."));
 //        try {
 //            GitHubGlobalSearchService searchService = new GitHubGlobalSearchService(gitHubClient);
 //            List<SearchResult> searchResults = searchService.searchAllPullRequests(trackerId);
 //            return searchResults.stream()
-//                    .map(pr -> getPatch(pr.getUrl()))
+//                    .map(pr -> getPullRequest(pr.getUrl()))
 //                    .filter(patch -> patch != null)
 //                    .collect(Collectors.toList());
 //        } catch (IOException e) {
@@ -189,7 +189,7 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
 //    }
 
     @Override
-    public List<Patch> getPatchesByState(Repository repository, PatchState state) throws NotFoundException {
+    public List<PullRequest> getPullRequestsByState(Repository repository, PullRequestState state) throws NotFoundException {
         URL url = repository.getURL();
         checkHost(url);
 
@@ -204,7 +204,7 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
                 issueState = GHIssueState.OPEN;
             }
             List<GHPullRequest> pullRequests = githubRepository.getPullRequests(issueState);
-            return WRAPPER.toAphroditePatches(pullRequests);
+            return WRAPPER.toAphroditePullRequestes(pullRequests);
         } catch (IOException e) {
             Utils.logException(LOG, e);
             throw new NotFoundException(e);
@@ -212,11 +212,11 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
     }
 
     @Override
-    public void addCommentToPatch(Patch patch, String comment) throws NotFoundException {
-        URL url = patch.getURL();
+    public void addCommentToPullRequest(PullRequest pullRequest, String comment) throws NotFoundException {
+        URL url = pullRequest.getURL();
         checkHost(url);
 
-        int id = Integer.parseInt(patch.getId());
+        int id = Integer.parseInt(pullRequest.getId());
         String repositoryId = createFromUrl(url);
         try {
             GHRepository repository = github.getRepository(repositoryId);
@@ -250,16 +250,16 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
     }
 
     @Override
-    public void addLabelToPatch(Patch patch, String labelName) throws NotFoundException {
-        URL url = patch.getURL();
+    public void addLabelToPullRequest(PullRequest pullRequest, String labelName) throws NotFoundException {
+        URL url = pullRequest.getURL();
         checkHost(url);
 
-        int patchId = new Integer(Utils.getTrailingValueFromUrlPath(url));
+        int pullRequestId = new Integer(Utils.getTrailingValueFromUrlPath(url));
         String repositoryId = createFromUrl(url);
         try {
             GHRepository repository = github.getRepository(repositoryId);
             GHLabel newLabel = getLabel(repository, labelName);
-            GHIssue issue = repository.getIssue(patchId);
+            GHIssue issue = repository.getIssue(pullRequestId);
             Collection<GHLabel> labels = issue.getLabels();
             if (labels.contains(newLabel)) {
                 return;
@@ -304,18 +304,18 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
             throw new NotFoundException(e);
         }
 
-        return WRAPPER.pullRequestLabeltoPatchLabel(labels);
+        return WRAPPER.pullRequestLabeltoPullRequestLabel(labels);
     }
 
     @Override
-    public List<Label> getLabelsFromPatch(Patch patch) throws NotFoundException {
-        URL url = patch.getURL();
+    public List<Label> getLabelsFromPullRequest(PullRequest pullRequest) throws NotFoundException {
+        URL url = pullRequest.getURL();
         checkHost(url);
         String repositoryId = createFromUrl(url);
         try {
             GHRepository repository = github.getRepository(repositoryId);
-            GHIssue issue = repository.getIssue(Integer.parseInt(patch.getId()));
-            return WRAPPER.pullRequestLabeltoPatchLabel(issue.getLabels());
+            GHIssue issue = repository.getIssue(Integer.parseInt(pullRequest.getId()));
+            return WRAPPER.pullRequestLabeltoPullRequestLabel(issue.getLabels());
         } catch (IOException | NumberFormatException e) {
             Utils.logException(LOG, e);
             throw new NotFoundException(e);
@@ -323,15 +323,15 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
     }
 
     @Override
-    public void setLabelsToPatch(Patch patch, List<Label> labels) throws NotFoundException {
-        URL url = patch.getURL();
+    public void setLabelsToPullRequest(PullRequest pullRequest, List<Label> labels) throws NotFoundException {
+        URL url = pullRequest.getURL();
         checkHost(url);
 
-        int patchId = new Integer(Utils.getTrailingValueFromUrlPath(url));
+        int pullRequestId = new Integer(Utils.getTrailingValueFromUrlPath(url));
         String repositoryId = createFromUrl(url);
         try {
             GHRepository repository = github.getRepository(repositoryId);
-            GHIssue issue = repository.getIssue(patchId);
+            GHIssue issue = repository.getIssue(pullRequestId);
             List<GHLabel> issueLabels = new ArrayList<>();
             List<GHLabel> existingLabels = repository.listLabels().asList();
 
@@ -349,15 +349,15 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
     }
 
     @Override
-    public void removeLabelFromPatch(Patch patch, String name) throws NotFoundException {
-        URL url = patch.getURL();
+    public void removeLabelFromPullRequest(PullRequest pullRequest, String name) throws NotFoundException {
+        URL url = pullRequest.getURL();
         checkHost(url);
 
-        int patchId = new Integer(Utils.getTrailingValueFromUrlPath(url));
+        int pullRequestId = new Integer(Utils.getTrailingValueFromUrlPath(url));
         String repositoryId = createFromUrl(url);
         try {
             GHRepository repository = github.getRepository(repositoryId);
-            GHIssue issue = repository.getIssue(patchId);
+            GHIssue issue = repository.getIssue(pullRequestId);
             Collection<GHLabel> labels = issue.getLabels();
 
             for (GHLabel label : labels)
@@ -385,25 +385,25 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
             .compile("([a-zA-Z_0-9-]*)/([a-zA-Z_0-9-]*)#(\\d+)", Pattern.CASE_INSENSITIVE);
 
     @Override
-    public List<Patch> findPatchesRelatedTo(Patch patch) {
+    public List<PullRequest> findPullRequestsRelatedTo(PullRequest pullRequest) {
         try {
-            List<URL> urls = getPRFromDescription(patch.getURL(), patch.getBody());
-            List<Patch> related = new ArrayList<>();
+            List<URL> urls = getPRFromDescription(pullRequest.getURL(), pullRequest.getBody());
+            List<PullRequest> related = new ArrayList<>();
             for (URL url : urls) {
                 try {
-                    // Only try and retrieve patch if it is located on the same host as this service
+                    // Only try and retrieve pull request if it is located on the same host as this service
                     if (urlExists(url)) {
-                        related.add(getPatch(url));
+                        related.add(getPullRequest(url));
                     } else {
                         Utils.logWarnMessage(LOG, "Unable to process url '" + url + "' as it is not located on this service");
                     }
                 } catch (NotFoundException e) {
-                    Utils.logException(LOG, "Unable to retrieve url '" + url + "' referenced in the patch at: " + patch.getURL(), e);
+                    Utils.logException(LOG, "Unable to retrieve url '" + url + "' referenced in the pull request at: " + pullRequest.getURL(), e);
                 }
             }
             return related;
         } catch (MalformedURLException | URISyntaxException e) {
-            Utils.logException(LOG, "something went wrong while trying to get related patches to " + patch.getURL(), e);
+            Utils.logException(LOG, "something went wrong while trying to get related pull requests to " + pullRequest.getURL(), e);
             return Collections.emptyList();
         }
     }
@@ -446,20 +446,20 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
     }
 
     @Override
-    public CommitStatus getCommitStatusFromPatch(Patch patch) throws NotFoundException {
-        URL url = patch.getURL();
+    public CommitStatus getCommitStatusFromPullRequest(PullRequest pullRequest) throws NotFoundException {
+        URL url = pullRequest.getURL();
         checkHost(url);
 
         CommitStatus status = null;
-        int patchId = Integer.parseInt(patch.getId());
+        int pullRequestId = Integer.parseInt(pullRequest.getId());
         String repositoryId = createFromUrl(url);
         try {
             String sha = null;
 
             GHRepository repository = github.getRepository(repositoryId);
-            GHPullRequest pullRequest = repository.getPullRequest(patchId);
+            GHPullRequest ghPullRequest = repository.getPullRequest(pullRequestId);
 
-            List<GHPullRequestCommitDetail> commits = pullRequest.listCommits().asList();
+            List<GHPullRequestCommitDetail> commits = ghPullRequest.listCommits().asList();
             if (commits.size() > 0) {
                 sha = commits.get(commits.size() - 1).getSha();
             }

--- a/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubWrapper.java
+++ b/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubWrapper.java
@@ -56,7 +56,7 @@ class GitHubWrapper {
         return repo;
     }
 
-    List<PullRequest> toAphroditePullRequestes(List<GHPullRequest> pullRequests) {
+    List<PullRequest> toAphroditePullRequests(List<GHPullRequest> pullRequests) {
         return pullRequests.stream()
                 .map(this::pullRequestToPullRequest)
                 .collect(Collectors.toList());

--- a/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubWrapper.java
+++ b/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubWrapper.java
@@ -24,8 +24,8 @@ package org.jboss.set.aphrodite.repository.services.github;
 
 import org.jboss.set.aphrodite.domain.Codebase;
 import org.jboss.set.aphrodite.domain.Label;
-import org.jboss.set.aphrodite.domain.Patch;
-import org.jboss.set.aphrodite.domain.PatchState;
+import org.jboss.set.aphrodite.domain.PullRequest;
+import org.jboss.set.aphrodite.domain.PullRequestState;
 import org.jboss.set.aphrodite.domain.RateLimit;
 import org.jboss.set.aphrodite.domain.Repository;
 import org.kohsuke.github.GHBranch;
@@ -56,18 +56,18 @@ class GitHubWrapper {
         return repo;
     }
 
-    List<Patch> toAphroditePatches(List<GHPullRequest> pullRequests) {
+    List<PullRequest> toAphroditePullRequestes(List<GHPullRequest> pullRequests) {
         return pullRequests.stream()
-                .map(this::pullRequestToPatch)
+                .map(this::pullRequestToPullRequest)
                 .collect(Collectors.toList());
     }
 
-    Patch pullRequestToPatch(GHPullRequest pullRequest) {
+    PullRequest pullRequestToPullRequest(GHPullRequest pullRequest) {
         try {
             String id = Integer.toString(pullRequest.getNumber());
             URL url = pullRequest.getHtmlUrl();
             Codebase codebase = new Codebase(pullRequest.getBase().getRef());
-            PatchState state = getPatchState(pullRequest.getState());
+            PullRequestState state = getPullRequestState(pullRequest.getState());
             String title = pullRequest.getTitle().replaceFirst("\\u2026", "");
             String body = pullRequest.getBody().replaceFirst("\\u2026", "");
 
@@ -78,13 +78,13 @@ class GitHubWrapper {
             }
             Repository repo = new Repository(URI.create(urlString).toURL());
 
-            return new Patch(id, url, repo, codebase, state, title, body);
+            return new PullRequest(id, url, repo, codebase, state, title, body);
         } catch (MalformedURLException e) {
             return null;
         }
     }
 
-    public List<Label> pullRequestLabeltoPatchLabel(Collection<GHLabel> labels) {
+    public List<Label> pullRequestLabeltoPullRequestLabel(Collection<GHLabel> labels) {
         List<Label> patchLabels = new ArrayList<>();
         for (GHLabel label : labels) {
             String name = label.getName();
@@ -96,11 +96,11 @@ class GitHubWrapper {
         return patchLabels;
     }
 
-    public static PatchState getPatchState(GHIssueState state) {
+    public static PullRequestState getPullRequestState(GHIssueState state) {
         try {
-            return PatchState.valueOf(state.toString().toUpperCase());
+            return PullRequestState.valueOf(state.toString().toUpperCase());
         } catch (IllegalArgumentException e) {
-            return PatchState.UNDEFINED;
+            return PullRequestState.UNDEFINED;
         }
     }
 

--- a/github/src/test/java/org/jboss/set/aphrodite/repository/services/GitHubGetCommitStatusTest.java
+++ b/github/src/test/java/org/jboss/set/aphrodite/repository/services/GitHubGetCommitStatusTest.java
@@ -26,7 +26,7 @@ import java.net.URL;
 import static org.mockito.Mockito.when;
 import org.jboss.set.aphrodite.Aphrodite;
 import org.jboss.set.aphrodite.domain.CommitStatus;
-import org.jboss.set.aphrodite.domain.Patch;
+import org.jboss.set.aphrodite.domain.PullRequest;
 import org.jboss.set.aphrodite.spi.NotFoundException;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,9 +43,9 @@ public class GitHubGetCommitStatusTest {
 
     @Mock
     Aphrodite aphrodite;
-    private Patch singleComPatch;
-    private Patch multipComPatch;
-    private Patch otherStatPatch;
+    private PullRequest singleComPullRequest;
+    private PullRequest multipComPullRequest;
+    private PullRequest otherStatPullRequest;
     private CommitStatus singleStatus;
     private CommitStatus multipStatus;
     private CommitStatus otherStatus;
@@ -63,30 +63,30 @@ public class GitHubGetCommitStatusTest {
         multipURL = new URL("https://github.com/jboss-set/aphrodite/pull/40");
         otherURL = new URL("https://github.com/jboss-set/aphrodite/pull/15");
 
-        singleComPatch = new Patch(singleId, singleURL, null, null, null);
-        multipComPatch = new Patch(multipId, multipURL, null, null, null);
-        otherStatPatch = new Patch(otherId, otherURL, null, null, null);
+        singleComPullRequest = new PullRequest(singleId, singleURL, null, null, null);
+        multipComPullRequest = new PullRequest(multipId, multipURL, null, null, null);
+        otherStatPullRequest = new PullRequest(otherId, otherURL, null, null, null);
 
-        when(aphrodite.getCommitStatusFromPatch(singleComPatch)).thenReturn(CommitStatus.SUCCESS);
-        when(aphrodite.getCommitStatusFromPatch(multipComPatch)).thenReturn(CommitStatus.SUCCESS);
-        when(aphrodite.getCommitStatusFromPatch(otherStatPatch)).thenReturn(CommitStatus.FAILURE);
+        when(aphrodite.getCommitStatusFromPullRequest(singleComPullRequest)).thenReturn(CommitStatus.SUCCESS);
+        when(aphrodite.getCommitStatusFromPullRequest(multipComPullRequest)).thenReturn(CommitStatus.SUCCESS);
+        when(aphrodite.getCommitStatusFromPullRequest(otherStatPullRequest)).thenReturn(CommitStatus.FAILURE);
     }
 
     @Test
     public void singleCommitTest() throws NotFoundException {
-        singleStatus = aphrodite.getCommitStatusFromPatch(singleComPatch);
+        singleStatus = aphrodite.getCommitStatusFromPullRequest(singleComPullRequest);
         assertEquals("bug single commit status misMatch", CommitStatus.SUCCESS, singleStatus);
     }
 
     @Test
     public void multipCommitTest() throws NotFoundException {
-        multipStatus = aphrodite.getCommitStatusFromPatch(multipComPatch);
+        multipStatus = aphrodite.getCommitStatusFromPullRequest(multipComPullRequest);
         assertEquals("bug multip commit status misMatch", CommitStatus.SUCCESS, multipStatus);
     }
 
     @Test
     public void otherStatusTest() throws NotFoundException {
-        otherStatus = aphrodite.getCommitStatusFromPatch(otherStatPatch);
+        otherStatus = aphrodite.getCommitStatusFromPullRequest(otherStatPullRequest);
         assertEquals("bug other status miMatch", CommitStatus.FAILURE, otherStatus);
     }
 }

--- a/github/src/test/java/org/jboss/set/aphrodite/repository/services/GitHubLabelTest.java
+++ b/github/src/test/java/org/jboss/set/aphrodite/repository/services/GitHubLabelTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import static org.mockito.Mockito.when;
 import org.jboss.set.aphrodite.Aphrodite;
 import org.jboss.set.aphrodite.domain.Label;
-import org.jboss.set.aphrodite.domain.Patch;
+import org.jboss.set.aphrodite.domain.PullRequest;
 import org.jboss.set.aphrodite.domain.Repository;
 import org.jboss.set.aphrodite.spi.AphroditeException;
 import org.jboss.set.aphrodite.spi.NotFoundException;
@@ -61,7 +61,7 @@ public class GitHubLabelTest {
     @Mock
     private Aphrodite aphrodite;
     @Mock
-    private Patch patch;
+    private PullRequest pullRequest;
     @Mock
     private Repository repository;
 
@@ -127,7 +127,7 @@ public class GitHubLabelTest {
 
     @Test
     public void getLabelsfromPatchTest() throws NotFoundException {
-        prlabelsTest = aphrodite.getLabelsFromPatch(patch);
+        prlabelsTest = aphrodite.getLabelsFromPullRequest(pullRequest);
 
         Label label1 = prlabelsTest.get(0);
         assertEquals("bug color mismatch", "fc2929", label1.getColor());
@@ -167,9 +167,9 @@ public class GitHubLabelTest {
                 else
                     throw new RuntimeException();
             }
-        }).when(aphrodite).setLabelsToPatch(patch, addlabel);
+        }).when(aphrodite).setLabelsToPullRequest(pullRequest, addlabel);
 
-        aphrodite.setLabelsToPatch(patch, addlabel);
+        aphrodite.setLabelsToPullRequest(pullRequest, addlabel);
     }
 
     @Test
@@ -190,9 +190,9 @@ public class GitHubLabelTest {
                 else
                     throw new RuntimeException();
             }
-        }).when(aphrodite).removeLabelFromPatch(patch, labelname);
+        }).when(aphrodite).removeLabelFromPullRequest(pullRequest, labelname);
 
-        aphrodite.removeLabelFromPatch(patch, labelname);
+        aphrodite.removeLabelFromPullRequest(pullRequest, labelname);
         ;
     }
 
@@ -223,7 +223,7 @@ public class GitHubLabelTest {
 
     private void mockLabel() throws NotFoundException {
         when(aphrodite.getLabelsFromRepository(repository)).thenReturn(labels);
-        when(aphrodite.getLabelsFromPatch(patch)).thenReturn(prlabels);
+        when(aphrodite.getLabelsFromPullRequest(pullRequest)).thenReturn(prlabels);
 
     }
 }


### PR DESCRIPTION
1. Patch -> PullRequest rename to untangle pull request from patch.

2. Add Patch to domain model stick to Issue and allow to call different service implementations from Issue itself.  Patch represents any found url (from Issue itself) of possible types: 

- Pull Request URL: Git Pull Request e.g. https://github.com/jbossas/jboss-eap7/pull/1101 
In Jira, it looks for URL in field 'Git Pull Request'.
In Bugzilla, it looks for legitimate Git URL in comments.

- Commit URL: Git or SVN commit e.g. https://github.com/hibernate/hibernate-orm/commit/b053116bb42330971ac1357009b2d8879e21b3f0
In Jira, it looks for URL in field 'Git Pull Request'.
In Bugzilla, it looks for legitimate Git/SVN commit URL in comments.
 

- File URL: Attachment Patch file URL

It's unusual to mix the spi into domain module, I put them there to avoid cyclic maven reference as other modules depend on domain.