### PR TITLE
Add links of incorporates issues into the JiraIssue.

### DIFF
--- a/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/IssueWrapper.java
+++ b/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/IssueWrapper.java
@@ -384,6 +384,7 @@ class IssueWrapper {
     private void setIssueDependencies(URL originalUrl, Issue issue, Iterable<com.atlassian.jira.rest.client.api.domain.IssueLink> links) {
         if (links == null)
             return;
+        final String INCORPORATES = "incorporates";
 
         for (com.atlassian.jira.rest.client.api.domain.IssueLink il : links) {
             // Add links of cloned to/from issues to the issue
@@ -391,6 +392,13 @@ class IssueWrapper {
                 URL url = trackerIdToBrowsableUrl(originalUrl, il.getTargetIssueKey());
                 ((JiraIssue) issue).getLinkedCloneIssues().add(url);
             }
+
+            // Add links of incorporates issues
+            if(il.getIssueLinkType().getDescription().equals(INCORPORATES)) {
+                URL url = trackerIdToBrowsableUrl(originalUrl, il.getTargetIssueKey());
+                ((JiraIssue) issue).getLinkedIncorporatesIssues().add(url);
+            }
+
             if (il.getIssueLinkType().getDirection().equals(Direction.INBOUND)) {
                 URL url = trackerIdToBrowsableUrl(originalUrl, il.getTargetIssueKey());
                 issue.getBlocks().add(url);

--- a/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssue.java
+++ b/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssue.java
@@ -52,6 +52,8 @@ public class JiraIssue extends Issue {
     //Links to issues cloned from/to
     private List<URL> linkedCloneIssues = new ArrayList<>();
 
+    private List<URL> linkedIncorporatesIssues = new ArrayList<>();
+
     public JiraIssue(final URL url) {
         super(url, JIRA);
     }
@@ -118,5 +120,13 @@ public class JiraIssue extends Issue {
             upstreamReferences = super.getUpstreamReferences();
         }
         return upstreamReferences;
+    }
+
+    public List<URL> getLinkedIncorporatesIssues() {
+        return linkedIncorporatesIssues;
+    }
+
+    public void setLinkedIncorporatesIssues(List<URL> linkedIncorporatesIssues) {
+        this.linkedIncorporatesIssues = linkedIncorporatesIssues;
     }
 }


### PR DESCRIPTION
Expose incorporates links in the JiraIssue.

This is needed because of Bugclerk issue: https://github.com/jboss-set/bug-clerk/issues/64 .