### PR TITLE
Make repositories not mandatory - BugClerk don't need it 

### DIFF
--- a/common/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
@@ -190,9 +190,8 @@ public class Aphrodite implements AutoCloseable {
         if (issueTrackers.isEmpty())
             throw new AphroditeException("Unable to initiatilise Aphrodite, as a valid " + IssueTrackerService.class.getName() + " does not exist.");
 
-        if (repositories.isEmpty())
-            throw new AphroditeException(
-                    "Unable to initiatilise Aphrodite, as a valid " + RepositoryService.class.getName() + " does not exist.");
+        if (repositories.isEmpty() && LOG.isWarnEnabled() )
+            LOG.warn("Unable to initiatilise Aphrodite, as a valid " + RepositoryService.class.getName() + " does not exist.");
 
         initialiseStreams(mutableConfig);
         //TODO: make this configurable.


### PR DESCRIPTION
BugClerk does not uses any repositories definition, so throwing exception is breaking it.