### PR TITLE
Move methods which are entities' responsibility into entities

### DIFF
--- a/common/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
@@ -75,6 +75,7 @@ import org.jboss.set.aphrodite.spi.StreamService;
 
 public class Aphrodite implements AutoCloseable {
 
+    @SuppressWarnings("WeakerAccess")
     public static final String FILE_PROPERTY = "aphrodite.config";
 
     private static final Log LOG = LogFactory.getLog(Aphrodite.class);
@@ -104,7 +105,7 @@ public class Aphrodite implements AutoCloseable {
      *
      * @param config an <code>AphroditeConfig</code> object containing all configuration data.
      * @return instance the singleton instance of the Aphrodite service.
-     * @throws AphroditeException
+     * @throws AphroditeException if initialization fails
      * @throws IllegalStateException if an <code>Aphrodite</code> service has already been initialised.
      */
     public static synchronized Aphrodite instance(AphroditeConfig config) throws AphroditeException {
@@ -249,6 +250,7 @@ public class Aphrodite implements AutoCloseable {
      * @throws NotFoundException - if there is linked issue but either no tracker or issue does not exist in tracker
      * @throws MalformedURLException
      */
+    @Deprecated
     public Issue getIssue(final PullRequest pullRequest) throws NotFoundException, MalformedURLException {
         Objects.requireNonNull(pullRequest, "pull request cannot be null");
         checkIssueTrackerExists();
@@ -273,6 +275,7 @@ public class Aphrodite implements AutoCloseable {
      * @throws NotFoundException - if there is linked issue but either no tracker or issue does not exist in tracker
      * @throws MalformedURLException
      */
+    @Deprecated
     public List<Issue> getRelatedIssues(final PullRequest pullRequest) throws MalformedURLException, NotFoundException {
         Objects.requireNonNull(pullRequest, "pull request cannot be null");
         checkIssueTrackerExists();
@@ -302,6 +305,7 @@ public class Aphrodite implements AutoCloseable {
      * @throws NotFoundException - if there is linked issue but either no tracker or issue does not exist in tracker
      * @throws MalformedURLException
      */
+    @Deprecated
     public Issue getUpstreamIssue(final PullRequest pullRequest) throws NotFoundException, MalformedURLException {
         Objects.requireNonNull(pullRequest, "pull request cannot be null");
         checkIssueTrackerExists();
@@ -330,6 +334,7 @@ public class Aphrodite implements AutoCloseable {
      * @throws NotFoundException - if there is linked PR but either no tracker or issue does not exist in tracker
      * @throws MalformedURLException
      */
+    @Deprecated
     public PullRequest getUpstreamPullRequest(final PullRequest pullRequest) throws MalformedURLException, NotFoundException {
         Objects.requireNonNull(pullRequest, "pull request cannot be null");
         checkIssueTrackerExists();
@@ -345,6 +350,7 @@ public class Aphrodite implements AutoCloseable {
         }
     }
 
+    @Deprecated
     public PullRequestUpgrade getPullRequestUpgrade(final PullRequest pullRequest) {
         if (!hasUpgrade(pullRequest)) {
             return null;
@@ -369,6 +375,7 @@ public class Aphrodite implements AutoCloseable {
      * @param pullRequest
      * @return
      */
+    @Deprecated
     public boolean isUpstreamRequired(final PullRequest pullRequest) {
         Objects.requireNonNull(pullRequest, "pull request cannot be null");
         checkIssueTrackerExists();
@@ -382,6 +389,7 @@ public class Aphrodite implements AutoCloseable {
      * @param pullRequest
      * @return
      */
+    @Deprecated
     public boolean hasUpgrade(PullRequest pullRequest) {
         Objects.requireNonNull(pullRequest, "pull request cannot be null");
         checkIssueTrackerExists();
@@ -593,6 +601,7 @@ public class Aphrodite implements AutoCloseable {
      * @return a list of all <code>Issue</code> objects, or an empty list if no issues can be found.
      * @deprecated
      */
+    @Deprecated
     public List<Issue> getIssuesAssociatedWith(PullRequest pullRequest) {
         checkIssueTrackerExists();
         Objects.requireNonNull(pullRequest, "pull request cannot be null");
@@ -647,7 +656,7 @@ public class Aphrodite implements AutoCloseable {
      * @param repository the <code>Repository</code> object whose associated PullRequests should be returned.
      * @param state the <code>PullRequestState</code> which the returned <code>PullRequest</code> objects must have.
      * @return a list of all matching <code>PullRequest</code> objects, or an empty list if no pullRequests can be found.
-     * @throws a <code>NotFoundException</code>, if an exception is encountered when trying to retrieve pullRequests from a RepositoryService
+     * @throws NotFoundException if an exception is encountered when trying to retrieve pullRequests from a RepositoryService
      */
     public List<PullRequest> getPullRequestsByState(Repository repository, PullRequestState state) throws NotFoundException {
         checkRepositoryServiceExists();
@@ -658,7 +667,7 @@ public class Aphrodite implements AutoCloseable {
             if (repositoryService.urlExists(repository.getURL()))
                 return repositoryService.getPullRequestsByState(repository, state);
         }
-        return new ArrayList<>();
+        return Collections.emptyList();
     }
 
     /**
@@ -693,7 +702,7 @@ public class Aphrodite implements AutoCloseable {
      * Retrieve all labels associated with the provided <code>PullRequest</code> in <code>Repository</code> object.
      * @param repository the <code>Repository<code> object whose associated labels should be returned.
      * @return a list of all matching <code>Label<code> objects, or an empty list if no labels can be found.
-     * @throws a <code>NotFoundException</code> if an error is encountered when trying to retrieve labels from a RepositoryService
+     * @throws NotFoundException if an error is encountered when trying to retrieve labels from a RepositoryService
      */
     public List<Label> getLabelsFromRepository(Repository repository) throws NotFoundException {
         checkRepositoryServiceExists();
@@ -703,14 +712,14 @@ public class Aphrodite implements AutoCloseable {
             if (repositoryService.urlExists(repository.getURL()))
                 return repositoryService.getLabelsFromRepository(repository);
         }
-        return new ArrayList<>();
+        return Collections.emptyList();
     }
 
     /**
      * Retrieve all labels associated with the provided <code>PullRequest</code> object.
-     * @param pull request the <code>PullRequest<code> object whose associated labels should be returned.
+     * @param pullRequest request the <code>PullRequest<code> object whose associated labels should be returned.
      * @return a list of all matching <code>Label<code> objects, or an empty list if no pull request can be found.
-     * @throws a <code>NotFoundException</code> if an error is encountered when trying to retrieve labels from a RepositoryService
+     * @throws NotFoundException if an error is encountered when trying to retrieve labels from a RepositoryService
      */
     public List<Label> getLabelsFromPullRequest(PullRequest pullRequest) throws NotFoundException {
         checkRepositoryServiceExists();
@@ -720,7 +729,7 @@ public class Aphrodite implements AutoCloseable {
             if (repositoryService.urlExists(pullRequest.getURL()))
                 return repositoryService.getLabelsFromPullRequest(pullRequest);
         }
-        return new ArrayList<>();
+        return Collections.emptyList();
     }
 
     /**
@@ -807,7 +816,7 @@ public class Aphrodite implements AutoCloseable {
      *
      * @param pullRequest the <code>PullRequest</code> to which the label will be applied.
      * @param labelName the name of the label to be applied.
-     * @throws a <code>NotFoundException</code> if the <code>PullRequest</code> cannot be found, or the labelName does not exist.
+     * @throws NotFoundException if the <code>PullRequest</code> cannot be found, or the labelName does not exist.
      */
     public void addLabelToPullRequest(PullRequest pullRequest, String labelName) throws NotFoundException {
         checkRepositoryServiceExists();
@@ -825,7 +834,7 @@ public class Aphrodite implements AutoCloseable {
      * provided pull request object. Note, this method fails silently if a pull request cannot be retrieved from a URL, with the error message
      * simply logged.
      *
-     * @param pull request the <code>PullRequest</code> object to be queried against
+     * @param pullRequest request the <code>PullRequest</code> object to be queried against
      * @return a list of PullRequest objects that are related to the supplied pull request object
      */
     public List<PullRequest> findPullRequestsRelatedTo(PullRequest pullRequest) {
@@ -897,7 +906,7 @@ public class Aphrodite implements AutoCloseable {
      */
     public boolean isCPReleased(String cpVersion) {
         Objects.requireNonNull(cpVersion, "CP version cannot be null");
-        boolean released = false;
+        boolean released;
         checkIssueTrackerExists();
         // No ideal means to find proper issue tracker by version except doing hard code EAP6/7 <-> BZ/JIRA.
         // This is a blind match to both issue trackers.

--- a/common/src/main/java/org/jboss/set/aphrodite/spi/RepositoryService.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/spi/RepositoryService.java
@@ -139,7 +139,7 @@ public interface RepositoryService {
 
     /**
      * Set the labels for the provided <code>PullRequest</code> object.
-     * @param pullRequset the <code>PullRequest</code> object whose will be set.
+     * @param pullRequest the <code>PullRequest</code> object whose will be set.
      * @param labels the <code>Label</code> apply to the <code>PullRequest</code>
      * @throws NotFoundException if the <code>Label</code> can not be found in the provided <code>PullRequest</code>
      * @throws AphroditeException if add the <code>Label<code> is not consistent with get labels

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/internal/URLUtils.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/internal/URLUtils.java
@@ -1,0 +1,56 @@
+package org.jboss.set.aphrodite.domain.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Tomas Hofman (thofman@redhat.com)
+ */
+public final class URLUtils {
+
+    /**
+     * Supports domain names and IPv4. Is more permissive than spec of course.
+     *
+     * TODO: IPv6 support.
+     */
+    public static final String URL_REGEX_STRING= "(http|ftp|https)://(\\w+(:\\w+)@)?([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\\.)+[a-zA-Z0-9]+(/[\\w.@?^=%&:/~+#-]*)?";
+    private static final Pattern URL_REGEX= Pattern.compile(URL_REGEX_STRING);
+
+    private URLUtils() {
+    }
+
+    /**
+     * Extracts URLs matching given pattern from given String.
+     *
+     * @param source String to extract URLs from.
+     * @param initialMatchPattern Pattern that URLs must match.
+     * @param multiple If false, return the first URL only, if true, return all.
+     * @return URLs matching <code>initialMatchPattern</code>
+     */
+    public static String[] extractURLs(final String source, final Pattern initialMatchPattern, final boolean multiple) {
+        Matcher m = initialMatchPattern.matcher(source);
+        if (m.find()) {
+            final String urlSource = source.substring(m.start(), m.end());
+            m = URL_REGEX.matcher(urlSource);
+            if (multiple) {
+                final List<String> urls = new ArrayList<>();
+                while (m.find()) {
+                    urls.add(urlSource.substring(m.start(), m.end()));
+                }
+                return urls.toArray(new String[urls.size()]);
+            } else {
+                // just to be thorough
+                if (m.find()) {
+                    return new String[] { urlSource.substring(m.start(), m.end()) };
+                } else {
+                    return null;
+                }
+            }
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/domain/src/test/java/org/jboss/set/aphrodite/domain/internal/URLUtilsTest.java
+++ b/domain/src/test/java/org/jboss/set/aphrodite/domain/internal/URLUtilsTest.java
@@ -1,0 +1,76 @@
+package org.jboss.set.aphrodite.domain.internal;
+
+import java.util.regex.Pattern;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Tomas Hofman (thofman@redhat.com)
+ */
+public class URLUtilsTest {
+
+    private static String UPSTREAM_PR = "Upstream PR:";
+    private static String SIMPLE_URL = "http://issues.jboss.org/";
+    private static String SHORT_URL = "ftp://jboss.org";
+    private static String URL_WITH_CREDENTIALS = "https://tom:smurfs@issues.jboss.org";
+    private static String URL_WITH_PARAMETERS = "https://issues.jboss.org/browse/?filter=-1&true=true";
+    private static String URL_ALL_IN = "https://tom:smurfs@issues.jboss.org/browse/?filter=-1&true=true";
+    private static String URL_IPV4 = "https://1.2.3.4/a/b/c";
+    private static String INVALID_URL_MISSING_PROTO = "www.jboss.org";
+    private static String INVALID_URL_TOO_SHORT = "http://www";
+    private static String INVALID_URL_DASH_AT_THE_END = "http://www.jboss-.org";
+    private static String INVALID_URL_DOT_AT_THE_END = "http://www.jboss.org.";
+
+    /**
+     * Tests URLUtils.URL_REGEX_STRING constant
+     */
+    @Test
+    public void testUrlRegexConstant() {
+        Pattern initialPattern = Pattern.compile(URLUtils.URL_REGEX_STRING);
+
+        Assert.assertTrue(initialPattern.matcher(SIMPLE_URL).matches());
+        Assert.assertTrue(initialPattern.matcher(SHORT_URL).matches());
+        Assert.assertTrue(initialPattern.matcher(URL_WITH_CREDENTIALS).matches());
+        Assert.assertTrue(initialPattern.matcher(URL_WITH_PARAMETERS).matches());
+        Assert.assertTrue(initialPattern.matcher(URL_ALL_IN).matches());
+        Assert.assertTrue(initialPattern.matcher(URL_IPV4).matches());
+
+        Assert.assertFalse(initialPattern.matcher(INVALID_URL_MISSING_PROTO).matches());
+        Assert.assertFalse(initialPattern.matcher(INVALID_URL_TOO_SHORT).matches());
+        Assert.assertFalse(initialPattern.matcher(INVALID_URL_DASH_AT_THE_END).matches());
+        Assert.assertFalse(initialPattern.matcher(INVALID_URL_DOT_AT_THE_END).matches());
+    }
+
+    @Test
+    public void testExtractSingleUrl() {
+        String initialExp = UPSTREAM_PR + URLUtils.URL_REGEX_STRING;
+        final String text = "Some text, " + UPSTREAM_PR;
+        assertMatch(initialExp, text + SIMPLE_URL, SIMPLE_URL);
+        assertMatch(initialExp, text + SHORT_URL, SHORT_URL);
+        assertMatch(initialExp, text + URL_WITH_PARAMETERS, URL_WITH_PARAMETERS);
+        assertMatch(initialExp, text + URL_WITH_CREDENTIALS, URL_WITH_CREDENTIALS);
+        assertMatch(initialExp, text + URL_ALL_IN, URL_ALL_IN);
+    }
+
+    @Test
+    public void testExtractMultipleUrls() {
+        String initialExp = UPSTREAM_PR + URLUtils.URL_REGEX_STRING + ",(" + URLUtils.URL_REGEX_STRING + ")*";
+        final String text = "Some text, " + UPSTREAM_PR + SIMPLE_URL + "," + URL_WITH_PARAMETERS;
+
+        Pattern initialPattern = Pattern.compile(initialExp);
+        String[] urls = URLUtils.extractURLs(text, initialPattern, true);
+        Assert.assertNotNull(urls);
+        Assert.assertEquals(2, urls.length);
+        Assert.assertEquals(SIMPLE_URL, urls[0]);
+        Assert.assertEquals(URL_WITH_PARAMETERS, urls[1]);
+    }
+
+    private void assertMatch(String initialRegexp, String text, String expectedUrl) {
+        Pattern initialPattern = Pattern.compile(initialRegexp);
+        String[] urls = URLUtils.extractURLs(text, initialPattern, false);
+        Assert.assertNotNull(urls);
+        Assert.assertEquals(1, urls.length);
+        Assert.assertEquals(expectedUrl, urls[0]);
+    }
+}


### PR DESCRIPTION
Aphrodite#getIssue(PullRequest) -> PullRequest#findIssueURL()
Aphrodite#getRelatedIssues(PullRequest) -> PullRequest#findRelatedIssuesURL()
Aphrodite#getUpstreamIssue(PullRequest) -> PullRequest#findUpstreamIssueURL()
Aphrodite#getUpstreamPullRequest(PullRequest) -> PullRequest#findUpstreamPullRequestURL()
Aphrodite#getPullRequestUpgrade(PullRequest) -> PullRequest#findPullRequestUpgradeURL()
Aphrodite#isUpstreamRequired(PullRequest) -> PullRequest#isUpstreamRequired()
Aphrodite#hasUpgrade(PullRequest) -> PullRequest#hasUpgrade()

Aphrodite#extractURLs(String, Pattern, boolean) -> URLUtils#extractURLs(String, Pattern, boolean)

Plus some javadoc fixes.