### PR TITLE
upgrade github-api to 1.90

### DIFF
--- a/github/pom.xml
+++ b/github/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.77</version>
+            <version>1.90</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
GitHub object ids have exceeded the int range and as such are not getting correctly parsed. (I am not sure what the actual impact is, I just noticed errors being thrown when running `prbz-overview`)