### PR TITLE
Fix unexpected label addition from repository existing label list

### DIFF
--- a/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
+++ b/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
@@ -338,7 +338,6 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
             for (Label label : labels) {
                 issueLabels.add(getLabel(repository, label.getName(), existingLabels));
             }
-            issueLabels.add(existingLabels.get(0));
             List<String> list = issueLabels.stream().map(e -> e.getName()).collect(Collectors.toList());
             String[] labelArray = list.toArray(new String[list.size()]);
             issue.setLabels(labelArray);


### PR DESCRIPTION
`issueLabels.add(existingLabels.get(0));` looks wrong. It doesn't make sense to add first element (index 0) from repository existing label list. It could add an unexpected label.

I ran across it when I test pull-request-processor against 7.1.x branch. See https://github.com/jbossas/jboss-eap7/pull/2499 This issue causes unwanted 7.0.x label which is the first one in repository label list.

It luckily does not cause trouble on 7.0.x branch as 7.0.x is expected label value.