### PR TITLE
Issue 142 unify label manipulation methods arguments type

### DIFF
--- a/common/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/Aphrodite.java
@@ -776,18 +776,18 @@ public class Aphrodite implements AutoCloseable {
     /**
      * Delete a label from the provided <code>PullRequest</code> object.
      * @param pullRequest the <code>PullRequest</code> whose label will be removed.
-     * @param name the <code>Label</code> name will be removed.
+     * @param label the <code>Label</code> will be removed.
      * @throws NotFoundException if the <code>Label</code> name can not be found in the provided <code>PullRequest</code>, or an
      * exception occurs when contacting the RepositoryService
      */
-    public void removeLabelFromPullRequest(PullRequest pullRequest, String name) throws NotFoundException {
+    public void removeLabelFromPullRequest(PullRequest pullRequest, Label label) throws NotFoundException {
         checkRepositoryServiceExists();
         Objects.requireNonNull(pullRequest, "pull request cannot be null");
-        Objects.requireNonNull(name, "labelname cannot be null");
+        Objects.requireNonNull(label.getName(), "labelname cannot be null");
 
         for (RepositoryService repositoryService : repositories) {
             if (repositoryService.urlExists(pullRequest.getURL()))
-                repositoryService.removeLabelFromPullRequest(pullRequest, name);
+                repositoryService.removeLabelFromPullRequest(pullRequest, label);
         }
     }
 
@@ -819,17 +819,17 @@ public class Aphrodite implements AutoCloseable {
      * associated with the provided pull request then no further action is taken.
      *
      * @param pullRequest the <code>PullRequest</code> to which the label will be applied.
-     * @param labelName the name of the label to be applied.
+     * @param label the label to be applied.
      * @throws NotFoundException if the <code>PullRequest</code> cannot be found, or the labelName does not exist.
      */
-    public void addLabelToPullRequest(PullRequest pullRequest, String labelName) throws NotFoundException {
+    public void addLabelToPullRequest(PullRequest pullRequest, Label label) throws NotFoundException {
         checkRepositoryServiceExists();
         Objects.requireNonNull(pullRequest, "pull request cannot be null");
-        Objects.requireNonNull(labelName, "labelName cannot be null");
+        Objects.requireNonNull(label.getName(), "labelName cannot be null");
 
         for (RepositoryService repositoryService : repositories) {
             if (repositoryService.urlExists(pullRequest.getURL()))
-                repositoryService.addLabelToPullRequest(pullRequest, labelName);
+                repositoryService.addLabelToPullRequest(pullRequest, label);
         }
     }
 

--- a/common/src/main/java/org/jboss/set/aphrodite/spi/RepositoryService.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/spi/RepositoryService.java
@@ -149,10 +149,10 @@ public interface RepositoryService {
     /**
      *Delete a label from the provided <code>PullRequest</code> object.
      * @param pullRequest the <code>PullRequest</code> whose label will be removed.
-     * @param name the <code>Label</code> name will be removed.
+     * @param label the <code>Label</code> will be removed.
      * @throws NotFoundException if the <code>Label</code> name can not be found in the provided <code>PullRequest</code>
      */
-    void removeLabelFromPullRequest(PullRequest pullRequest, String name) throws NotFoundException;
+    void removeLabelFromPullRequest(PullRequest pullRequest, Label label) throws NotFoundException;
 
     /**
      * Add a <code>Comment</code> to the specified <code>PullRequest</code> object, and propagate the changes
@@ -170,10 +170,10 @@ public interface RepositoryService {
      * associated with the provided pull request then no further action is taken.
      *
      * @param pullRequest the <code>PullRequest</code> to which the label will be applied.
-     * @param labelName the name of the label to be applied.
+     * @param label the label to be applied.
      * @throws NotFoundException if the specified labelName has not been defined at the remote repository.
      */
-    void addLabelToPullRequest(PullRequest pullRequest, String labelName) throws NotFoundException;
+    void addLabelToPullRequest(PullRequest pullRequest, Label label) throws NotFoundException;
 
     /**
      * Find all the pull requests related to the given pull request.

--- a/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
+++ b/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubRepositoryService.java
@@ -250,7 +250,7 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
     }
 
     @Override
-    public void addLabelToPullRequest(PullRequest pullRequest, String labelName) throws NotFoundException {
+    public void addLabelToPullRequest(PullRequest pullRequest, Label label) throws NotFoundException {
         URL url = pullRequest.getURL();
         checkHost(url);
 
@@ -258,7 +258,7 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
         String repositoryId = createFromUrl(url);
         try {
             GHRepository repository = github.getRepository(repositoryId);
-            GHLabel newLabel = getLabel(repository, labelName);
+            GHLabel newLabel = getLabel(repository, label.getName());
             GHIssue issue = repository.getIssue(pullRequestId);
             Collection<GHLabel> labels = issue.getLabels();
             if (labels.contains(newLabel)) {
@@ -348,7 +348,7 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
     }
 
     @Override
-    public void removeLabelFromPullRequest(PullRequest pullRequest, String name) throws NotFoundException {
+    public void removeLabelFromPullRequest(PullRequest pullRequest, Label label) throws NotFoundException {
         URL url = pullRequest.getURL();
         checkHost(url);
 
@@ -359,8 +359,8 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
             GHIssue issue = repository.getIssue(pullRequestId);
             Collection<GHLabel> labels = issue.getLabels();
 
-            for (GHLabel label : labels)
-                if (label.getName().equalsIgnoreCase(name)) {
+            for (GHLabel l : labels)
+                if (l.getName().equalsIgnoreCase(label.getName())) {
                     // remove the label and reset
                     List<String> list = labels.stream().map(e -> e.getName()).collect(Collectors.toList());
                     list.remove(label.getName());
@@ -372,8 +372,8 @@ public class GitHubRepositoryService extends AbstractRepositoryService {
             Utils.logException(LOG, e);
             throw new NotFoundException(e);
         }
-        throw new NotFoundException("No label exists with the name '" + name +
-                "' at repository '" + repositoryId + "'");
+        throw new NotFoundException("No label exists with the name '" + label.getName() + "' at repository '" + repositoryId + "'");
+
     }
 
     private static final Pattern RELATED_PR_PATTERN = Pattern

--- a/github/src/test/java/org/jboss/set/aphrodite/repository/services/GitHubLabelTest.java
+++ b/github/src/test/java/org/jboss/set/aphrodite/repository/services/GitHubLabelTest.java
@@ -56,7 +56,7 @@ public class GitHubLabelTest {
 
     private List<Label> labels, labelsTest;
     private List<Label> prlabels, prlabelsTest, addlabel;
-    private String labelname = "bug";
+    private Label label = new Label("1", "fc2929", "bug", "https://api.github.com/repos/abc/xyz/labels/bug");
 
     @Mock
     private Aphrodite aphrodite;
@@ -179,9 +179,9 @@ public class GitHubLabelTest {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 Object[] args = invocation.getArguments();
-                labelname = (String) args[1];
+                label = (Label) args[1];
                 for (Label label : prlabels) {
-                    if (label.getName().equals(labelname)) {
+                    if (label.getName().equals(label.getName())) {
                         prlabels.remove(label);
                     }
                 }
@@ -190,9 +190,9 @@ public class GitHubLabelTest {
                 else
                     throw new RuntimeException();
             }
-        }).when(aphrodite).removeLabelFromPullRequest(pullRequest, labelname);
+        }).when(aphrodite).removeLabelFromPullRequest(pullRequest, label);
 
-        aphrodite.removeLabelFromPullRequest(pullRequest, labelname);
+        aphrodite.removeLabelFromPullRequest(pullRequest, label);
         ;
     }
 


### PR DESCRIPTION
I faced this issue when I was working with pull-processor. 
I make the API change here as the only sub tool operates on label is pull-processor, I would like to make relevant changes there once this is accepted.  Otherwise, I can keep and deprecate old API and add a new one to correct the argument type. 

this closes #142 