### PR TITLE
make tracker accept alternative JIRA paths

### DIFF
--- a/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraFields.java
+++ b/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraFields.java
@@ -22,6 +22,8 @@
 
 package org.jboss.set.aphrodite.issue.trackers.jira;
 
+import java.util.regex.Pattern;
+
 import org.jboss.set.aphrodite.domain.Flag;
 import org.jboss.set.aphrodite.domain.Issue;
 import org.jboss.set.aphrodite.domain.IssuePriority;
@@ -39,6 +41,7 @@ class JiraFields {
     static final String API_BASE_PATH = "/rest/api/2/";
     static final String API_ISSUE_PATH = API_BASE_PATH + "issue/";
     static final String BROWSE_ISSUE_PATH = "/browse/";
+    static final Pattern PROJECTS_ISSUE_PATTERN = Pattern.compile("\\/projects\\/[^\\/]+\\/issues\\/");
 
     static final String DATE_STRING_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZ";
     static final String JSON_CUSTOM_FIELD = "customfield_";

--- a/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssueTracker.java
+++ b/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssueTracker.java
@@ -25,6 +25,7 @@ package org.jboss.set.aphrodite.issue.trackers.jira;
 import static org.jboss.set.aphrodite.issue.trackers.jira.JiraFields.API_ISSUE_PATH;
 import static org.jboss.set.aphrodite.issue.trackers.jira.JiraFields.BROWSE_ISSUE_PATH;
 import static org.jboss.set.aphrodite.issue.trackers.jira.JiraFields.FLAG_MAP;
+import static org.jboss.set.aphrodite.issue.trackers.jira.JiraFields.PROJECTS_ISSUE_PATTERN;
 import static org.jboss.set.aphrodite.issue.trackers.jira.JiraFields.TARGET_RELEASE;
 import static org.jboss.set.aphrodite.issue.trackers.jira.JiraFields.getJiraTransition;
 
@@ -345,7 +346,7 @@ public class JiraIssueTracker extends AbstractIssueTracker {
     }
 
     private String getIssueKey(URL url) throws NotFoundException {
-        String path = url.getPath();
+        String path = correctPath(url.getPath());
         boolean api = path.contains(API_ISSUE_PATH);
         boolean browse = path.contains(BROWSE_ISSUE_PATH);
 
@@ -353,6 +354,14 @@ public class JiraIssueTracker extends AbstractIssueTracker {
             throw new NotFoundException("The URL path must be of the form '" + API_ISSUE_PATH + "' OR '" + BROWSE_ISSUE_PATH + "'");
 
         return api ? path.substring(API_ISSUE_PATH.length()) : path.substring(BROWSE_ISSUE_PATH.length());
+    }
+
+    private String correctPath(String path) {
+        Matcher m = PROJECTS_ISSUE_PATTERN.matcher(path);
+        if (m.find()) {
+            return m.replaceFirst(BROWSE_ISSUE_PATH);
+        }
+        return path;
     }
 
     private String getUpdateErrorMessage(Issue issue, Exception e) {


### PR DESCRIPTION
There's at least one PR linking to `https://issues.jboss.org/projects/<PROJECT_NAME>/issues/<ISSUE_KEY>`, there's no reason to refuse that URL when it contains the issue key.