### PR TITLE
[DO NOT MERGE] Payload and PayloadHome implementations.

### DIFF
--- a/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaFields.java
+++ b/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaFields.java
@@ -65,6 +65,7 @@ class BugzillaFields {
     static final String NAME = "name";
     static final String PRIVATE_COMMENT = "private";
     static final String PRODUCT = "product";
+    static final String PRODUCT_NAMES = "names";
     static final String REPORTER = "creator";
     static final String SUMMARY = "summary";
     static final String STATUS = "status";
@@ -73,6 +74,11 @@ class BugzillaFields {
     static final String TARGET_RELEASE = "target_release";
     static final String UPDATE_FIELDS = "updates";
     static final String VERSION = "version";
+
+    // product specific fields https://bugzilla.redhat.com/docs/en/html/api/Bugzilla/WebService/Product.html
+    static final String MILESTONES = "milestones";
+    static final String RELEASES = "releases";
+    static final String VERSIONS = "versions";
 
     static final String METHOD_GET_BUG = "Bug.get";
     static final String METHOD_UPDATE_BUG = "Bug.update";
@@ -83,10 +89,16 @@ class BugzillaFields {
     static final String METHOD_USER_LOGIN = "User.login";
     static final String METHOD_SET_COLLECTION = "set";
 
+    // product specific method https://bugzilla.redhat.com/docs/en/html/api/Bugzilla/WebService/Product.html
+    static final String METHOD_GET_PRODUCT = "Product.get";
+
     static final String RESULT_BUGS = "bugs";
     static final String RESULT_INCLUDE_FIELDS = "include_fields";
     static final String RESULT_LIMIT = "limit";
     static final String RESULT_PERMISSIVE_SEARCH = "permissive";
+
+    // product specific result https://bugzilla.redhat.com/docs/en/html/api/Bugzilla/WebService/Product.html
+    static final String RESULT_PRODUCTS = "products";
 
     static final String SEARCH_EQUALS = "equals";
     static final String SEARCH_FLAGS = "flagtypes.name";
@@ -99,6 +111,8 @@ class BugzillaFields {
             TARGET_RELEASE, VERSION, EXTERNAL_URL };
 
     static final Object[] COMMENT_FIELDS = { COMMENT_BUG_ID, COMMENT_ID, COMMENT_BODY, COMMENT_IS_PRIVATE };
+
+    static final Object[] PRODUCT_FIELDS = { ID, NAME, DESCRIPTION, COMPONENT, VERSIONS, MILESTONES, RELEASES };
 
     static Optional<Flag> getAphroditeFlag(String bzFlag) {
         switch (bzFlag) {

--- a/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaIssueTracker.java
+++ b/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaIssueTracker.java
@@ -154,4 +154,9 @@ public class BugzillaIssueTracker extends AbstractIssueTracker {
         }
         return false;
     }
+
+    @Override
+    public TrackerType getTrackerType() {
+        return this.TRACKER_TYPE;
+    }
 }

--- a/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaPayload.java
+++ b/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaPayload.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.aphrodite.issue.trackers.bugzilla;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jboss.set.aphrodite.Aphrodite;
+import org.jboss.set.aphrodite.domain.Issue;
+import org.jboss.set.aphrodite.domain.IssueStatus;
+import org.jboss.set.aphrodite.domain.Payload;
+import org.jboss.set.aphrodite.spi.AphroditeException;
+import org.jboss.set.aphrodite.spi.NotFoundException;
+
+/**
+ * @author wangc
+ *
+ */
+public class BugzillaPayload implements Payload {
+
+    private static final Logger logger = Logger.getLogger(BugzillaPayload.class.getCanonicalName());
+
+    private final Issue issue;
+
+    BugzillaPayload(final Issue issue) {
+        this.issue = issue;
+    }
+
+    @Override
+    public String getName() {
+        return issue.getSummary().orElse("N/A");
+    }
+
+    @Override
+    public URL getUrl() {
+        return issue.getURL();
+    }
+
+    @Override
+    public List<? extends Issue> getIssues() {
+        List<Issue> issues = new ArrayList<>();
+        for (URL url : issue.getDependsOn()) {
+            try {
+                Issue issue = Aphrodite.instance().getIssue(url);
+                issues.add(issue);
+            } catch (NotFoundException e) {
+                logger.log(Level.WARNING, "No issue found from url: " + url);
+            } catch (AphroditeException e) {
+                logger.log(Level.SEVERE, "Failed to get aphrodite instance", e);
+            }
+        }
+        return issues;
+    }
+
+    @Override
+    public boolean isReleased() {
+        if ((issue.getStatus().equals(IssueStatus.CLOSED) || issue.getStatus().equals(IssueStatus.VERIFIED))) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int getSize() {
+        return this.issue.getDependsOn().size();
+    }
+}

--- a/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaPayloadHome.java
+++ b/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaPayloadHome.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.aphrodite.issue.trackers.bugzilla;
+
+import static org.jboss.set.aphrodite.issue.trackers.bugzilla.BugzillaFields.ID_QUERY;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jboss.set.aphrodite.Aphrodite;
+import org.jboss.set.aphrodite.domain.Issue;
+import org.jboss.set.aphrodite.domain.Payload;
+import org.jboss.set.aphrodite.domain.spi.PayloadHome;
+import org.jboss.set.aphrodite.spi.AphroditeException;
+import org.jboss.set.aphrodite.spi.NotFoundException;
+
+public class BugzillaPayloadHome implements PayloadHome {
+
+    private static final Logger logger = Logger.getLogger(BugzillaPayloadHome.class.getCanonicalName());
+
+    private static final String BUGZILLA_HOST = "https://bugzilla.redhat.com/";
+
+    @Override
+    public Payload findPayload(String name) {
+        if (!name.startsWith("eap64") || !name.endsWith("-payload")) {
+            logger.log(Level.WARNING, "Incorrect bugzilla payload alias name format " + name);
+        }
+        // URL with alias format https://bugzilla.redhat.com/show_bug.cgi?id=eap6420-payload
+        String url = BUGZILLA_HOST + ID_QUERY + name;
+        try {
+            Issue issue = Aphrodite.instance().getIssue(new URL(url));
+            return new BugzillaPayload(issue);
+        } catch (MalformedURLException e) {
+            logger.log(Level.WARNING, "Unable to form URL from " + url, e);
+        } catch (NotFoundException e) {
+            logger.log(Level.WARNING, "Unable to find bugzilla payload parent tracker issue from " + url, e);
+        } catch (AphroditeException e) {
+            logger.log(Level.SEVERE, "Failed to get aphrodite instance", e);
+        }
+        return null;
+    }
+
+    @Override
+    public List<Payload> findAllPayloads() {
+        // TODO how to find all Bugzilla payload by alias (ap6420-payload) ?
+        throw new RuntimeException("NYI: org.jboss.set.aphrodite.issue.trackers.bugzilla.BugzillaPayloadHome.findAllPayloads");
+    }
+}

--- a/common/src/main/java/org/jboss/set/aphrodite/spi/IssueTrackerService.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/spi/IssueTrackerService.java
@@ -24,6 +24,7 @@ package org.jboss.set.aphrodite.spi;
 
 import org.jboss.set.aphrodite.config.AphroditeConfig;
 import org.jboss.set.aphrodite.config.IssueTrackerConfig;
+import org.jboss.set.aphrodite.config.TrackerType;
 import org.jboss.set.aphrodite.domain.Comment;
 import org.jboss.set.aphrodite.domain.Issue;
 import org.jboss.set.aphrodite.domain.PullRequest;
@@ -71,6 +72,12 @@ public interface IssueTrackerService {
      * @return
      */
     String getTrackerID();
+
+    /**
+     * Return the tracker type defined in {@link TrackerType}.
+     * @return tracker type
+     */
+    TrackerType getTrackerType();
 
     /**
      * Retrieve all Issues associated with the provided pullRequest object.

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/Payload.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/Payload.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.aphrodite.domain;
+
+import java.net.URL;
+import java.util.List;
+
+/**
+ * @author wangc
+ *
+ */
+public interface Payload {
+
+    /**
+     * Retrieve the name of payload. In Jira, it's represented by the fixed version name which defines payload e.g. "7.1.1.GA".
+     * In Bugzilla, it's represented by the string summary of the parent tracker bug. e.g. "EAP 6.4.15 (CP15) Payload Tracker"
+     *
+     * @return the name of payload.
+     */
+    String getName();
+
+    /**
+     * Retrieve the payload relevant URL link. In Jira, it's the version link e.g.
+     * https://issues.jboss.org/projects/JBEAP/versions/12332890. In Bugzilla, it's the parent tracker bug URL e.g.
+     * https://bugzilla.redhat.com/show_bug.cgi?id=1510090
+     *
+     * @return the URL of payload, null in case of MalformedURLException.
+     */
+    URL getUrl();
+
+    /**
+     * Retrieve all issues associated with current payload.
+     *
+     * @return a list of issues in payload
+     */
+    List<? extends Issue> getIssues();
+
+    /**
+     * Get the payload size.
+     *
+     * @return an integer represents payload size.
+     */
+    int getSize();
+
+    /**
+     * Check if a given payload is released. Jira payload is released if the associated version is released. Bugzilla payload is
+     * released if the parent tracker bug is VERIFIED or CLOSED.
+     *
+     * @return true if the payload is released, otherwise false.
+     */
+    boolean isReleased();
+
+}

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/spi/PayloadHome.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/spi/PayloadHome.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.aphrodite.domain.spi;
+
+import java.util.List;
+
+import org.jboss.set.aphrodite.domain.Payload;
+
+/**
+ * @author wangc
+ *
+ */
+public interface PayloadHome {
+
+    /**
+     * Retrieve payload by a given name. It accepts Jira fixed version format x.y.z.GA, Bugzilla parent bug alias format
+     * eap6420-payload.
+     *
+     * @param name a string of payload name.
+     * @return a <code>Payload</code> instance if given name matches an existing payload, otherwise return null.
+     */
+    Payload findPayload(String name);
+
+    /**
+     * Retrieve all payload by a given project / product name from issue trackers.
+     *
+     * @return a list of existing <code>Payload</code>
+     */
+    List<Payload> findAllPayloads();
+
+}

--- a/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraPayload.java
+++ b/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraPayload.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.aphrodite.issue.trackers.jira;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jboss.set.aphrodite.Aphrodite;
+import org.jboss.set.aphrodite.domain.Issue;
+import org.jboss.set.aphrodite.domain.Payload;
+import org.jboss.set.aphrodite.domain.Release;
+import org.jboss.set.aphrodite.domain.SearchCriteria;
+import org.jboss.set.aphrodite.spi.AphroditeException;
+
+import com.atlassian.jira.rest.client.api.domain.Version;
+
+/**
+ * @author wangc
+ *
+ */
+public class JiraPayload implements Payload {
+
+    private static final boolean devProfile = System.getProperty("dev") != null;
+
+    private static final Logger logger = Logger.getLogger(JiraPayload.class.getCanonicalName());
+
+    private final Version version;
+    private URL url;
+    private List<? extends Issue> issues;
+
+    JiraPayload(Version version) {
+        this.version = version;
+    }
+
+    @Override
+    public String getName() {
+        return version.getName();
+    }
+
+    @Override
+    public URL getUrl() {
+        try {
+            this.url = version.getSelf().toURL();
+            return url;
+        } catch (MalformedURLException e) {
+            logger.log(Level.WARNING, "Unable to retrieve payload url from " + version.getSelf(), e);
+        }
+        return null;
+    }
+
+    @Override
+    public List<? extends Issue> getIssues() {
+        int maxResults = devProfile ? 10 : 200;
+        SearchCriteria sc = new SearchCriteria.Builder()
+                .setRelease(new Release(version.getName().trim()))
+                .setProduct("JBEAP")
+                .setMaxResults(maxResults)
+                .build();
+        try {
+            issues = Aphrodite.instance().searchIssues(sc);
+        } catch (AphroditeException e) {
+            issues = Collections.emptyList();
+            logger.log(Level.SEVERE, "Failed to get aphrodite instance", e);
+        }
+        return issues;
+    }
+
+    @Override
+    public int getSize() {
+        if (issues == null) {
+            getIssues();
+        }
+        return getIssues().size();
+    }
+
+    @Override
+    public boolean isReleased() {
+        return version.isReleased();
+    }
+
+    public Version getVersion() {
+        return version;
+    }
+
+}

--- a/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraPayloadHome.java
+++ b/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraPayloadHome.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.aphrodite.issue.trackers.jira;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.naming.NameNotFoundException;
+
+import org.jboss.set.aphrodite.container.Container;
+import org.jboss.set.aphrodite.domain.Payload;
+import org.jboss.set.aphrodite.domain.spi.PayloadHome;
+
+import com.atlassian.jira.rest.client.api.domain.Version;
+
+/**
+ * @author wangc
+ *
+ */
+public class JiraPayloadHome implements PayloadHome {
+
+    private static final Logger logger = Logger.getLogger(JiraPayloadHome.class.getCanonicalName());
+    private static final String PROJECT_NAME = "JBEAP";
+    private static final Pattern PAYLOAD_VERSION = Pattern.compile("[7-9].[0-9].[0-9]*.GA");
+
+    @Override
+    public Payload findPayload(String name) {
+        if (!PAYLOAD_VERSION.matcher(name).find()) {
+            logger.log(Level.WARNING, "Incorrect jira payload name " + name);
+        }
+
+        Version version;
+        try {
+            version = Container.instance().lookup(JiraIssueTracker.class.getSimpleName(), JiraIssueTracker.class).getVersionByName(PROJECT_NAME, name);
+            return new JiraPayload(version);
+        } catch (NameNotFoundException e) {
+            logger.log(Level.WARNING, "Missing service! It's unable to find payload by name " + name, e);
+        }
+        return null;
+    }
+
+    @Override
+    public List<Payload> findAllPayloads() {
+        List<Payload> payloads = new ArrayList<>();
+        try {
+            List<Version> versions = Container.instance().lookup(JiraIssueTracker.class.getSimpleName(), JiraIssueTracker.class).getVersionsByProject(PROJECT_NAME);
+            payloads = versions.stream()
+                    .filter(v -> filterPayloadVersion(v))
+                    .map(v -> new JiraPayload(v))
+                    .collect(Collectors.toList());
+        } catch (NameNotFoundException e) {
+            logger.log(Level.SEVERE, "Missing JiraIssueTracker service! It's unable to find payloads for project " + PROJECT_NAME, e);
+        }
+        return payloads;
+    }
+
+    // Examples: "6.1.0.Alpha1", "6.1.0.CR1", "6.1.0.GA", "6.1.1.GA", "6.2.0.GA", "6.3.0.GA", "6.4.0.GA", "7.0.0.DR12",
+    // "7.0.0.DR13 (Alpha)", "7.0.0.ER2 (Beta)", "7.0.0.ER7", "7.0.0.CR2", "7.0.0.GA", "7.0.3.CR3-doc","7.0.8.CR1","7.0.7.CR3",
+    // "7.0.7.CR1", "7.0.7.CR2", "7.0.9.GA", "7.0.10.GA", "7.1.0.DR19", "7.1.0.ER3","7.1.0.CR4", "7.1.0.GA", "7.0.z.GA",
+    // "7.1.1.GA", "7.2.0.GA", "7.1.z.GA", "7.Doc.Test", "Individual Patches.GA", "7.backlog.GA"
+    protected static boolean filterPayloadVersion(Version version) {
+        if (PAYLOAD_VERSION.matcher(version.getName()).find()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/jira/src/test/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssueTrackerTest.java
+++ b/jira/src/test/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssueTrackerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.aphrodite.issue.trackers.jira;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.atlassian.jira.rest.client.api.domain.Version;
+
+/**
+ * @author wangc
+ *
+ */
+public class JiraIssueTrackerTest {
+    private static final String PROJECT = "JBEAP";
+    private static List<Version> versions;
+
+    private JiraIssueTracker jiraIssueTracker;
+
+    static {
+        try {
+            versions = Arrays.asList(
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12321329"), (long) 12321329, "6.1.0.Alpha1", "EAP 6.1 Alpha release for the Community", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12321661"), (long) 12321661, "6.1.0.CR1", "EAP 6.1 Candidate Release", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12335686"), (long) 12335686, "7.0.10.GA", "EAP 7.0.10.GA Payload", false, false, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12331747"), (long) 12331747, "", "7.0.3.CR3-doc", false, false, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12329491"), (long) 12329491, "7.0.z.GA", "EAP 7.0.z Release Stream", false, false, new DateTime()),                    
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12332890"), (long) 12332890, "7.1.1.GA", "EAP 7.1.1.GA Payload", false, false, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12332773"), (long) 12332773, "7.2.0.GA", "EAP 7.2.0.GA Release", false, false, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12334325"), (long) 12334325, "7.1.z.GA", "EAP 7.1.z Release Stream", false, false, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12331159"), (long) 12331159, "7.Doc.Test", "Test of Docs fix version", false, false, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12330663"), (long) 12330663, "Individual Patches.GA", "Patches created for individual customers by the support team.", false, false, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12329564"), (long) 12329564, "7.backlog.GA", "EAP 7.x.z backlog", false, false, new DateTime())
+                    );
+        } catch (URISyntaxException e) {
+            // ignore
+        }
+    }
+
+    @Before
+    public void setup() {
+        jiraIssueTracker = mock(JiraIssueTracker.class);
+        mockJiraIssueTracker();
+    }
+
+    private void mockJiraIssueTracker() {
+        when(jiraIssueTracker.getVersionsByProject(PROJECT)).thenReturn(versions);
+    }
+
+    @Test
+    public void testGetVersionsByProject() {
+        List<Version> result = jiraIssueTracker.getVersionsByProject(PROJECT);
+        assertEquals("Should be equal", versions.size(), result.size());
+    }
+}

--- a/jira/src/test/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraPayloadHomeTest.java
+++ b/jira/src/test/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraPayloadHomeTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.set.aphrodite.issue.trackers.jira;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.joda.time.DateTime;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.atlassian.jira.rest.client.api.domain.Version;
+
+/**
+ * @author wangc
+ *
+ */
+public class JiraPayloadHomeTest {
+
+    private static List<Version> versions;
+
+    @BeforeClass
+    public static void setup() {
+        try {
+            versions = Arrays.asList(
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "6.1.0.Alpha1", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "6.1.0.CR1", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "6.1.0.GA", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "6.2.0.GA", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "6.1.1.GA", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "6.3.0.GA", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "6.4.0.GA", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.0.0.DR12", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.0.0.DR13 (Alpha)", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.0.0.ER2 (Beta)", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.0.0.ER7", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.0.0.CR2", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.0.0.GA", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.0.3.CR3-doc", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.1.0.CR4", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.1.0.GA", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.0.z.GA", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.1.1.GA", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.2.0.GA", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.1.z.GA", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.Doc.Test", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "Individual Patches.GA", "", false, true, new DateTime()),
+                    new Version(new URI("https://issues.jboss.org/rest/api/2/version/12345678"), (long) 12345678, "7.backlog.GA", "", false, true, new DateTime())
+                    );
+        } catch (URISyntaxException e) {
+            // ignore
+        }
+    }
+
+    @Test
+    public void testPayloadVersionFilter() {
+        int counter = 0;
+        for(Version version : versions) {
+            if(JiraPayloadHome.filterPayloadVersion(version)) {
+                counter++;
+            }
+        }
+        assertEquals(4, counter);
+    }
+
+}


### PR DESCRIPTION
This is a draft introduction of Payload and PayloadHome service implementations as requested in https://github.com/jboss-set/aphrodite/issues/174

JiraPayloadHome depends on JiraIssueTracker service to fetch Version back. Therefore this can not work properly until IssueTrackerService (maybe RepositoryService and StreamService as well) can be registered into container instead of initialization from Aphrodite.