### PR TITLE
Update jdk version for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk12
 install:  
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dcommunity
 script:


### PR DESCRIPTION
Travis no longer support jdk 8 in build job.
```
Expected feature release number in range of 9 to 14, but got: 8

The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .

Your build has been stopped.
```