### PR TITLE
[SET-238] add GitLab support to Aphrodite

### DIFF
--- a/common/src/main/java/org/jboss/set/aphrodite/repository/services/common/AbstractRepositoryService.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/repository/services/common/AbstractRepositoryService.java
@@ -89,4 +89,8 @@ public abstract class AbstractRepositoryService {
             throw new NotFoundException("The requested Repository cannot be found as it is not " +
                     "hosted on this server.");
     }
+
+    public URL getBaseUrl() {
+        return baseUrl;
+    }
 }

--- a/common/src/main/java/org/jboss/set/aphrodite/repository/services/common/RepositoryType.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/repository/services/common/RepositoryType.java
@@ -2,7 +2,8 @@ package org.jboss.set.aphrodite.repository.services.common;
 
 public enum RepositoryType {
 
-    GITHUB("github");
+    GITHUB("github"),
+    GITLAB("gitlab");
 
     private final String type;
 

--- a/common/src/main/java/org/jboss/set/aphrodite/spi/RepositoryService.java
+++ b/common/src/main/java/org/jboss/set/aphrodite/spi/RepositoryService.java
@@ -34,6 +34,7 @@ import org.jboss.set.aphrodite.domain.PullRequest;
 import org.jboss.set.aphrodite.domain.PullRequestState;
 import org.jboss.set.aphrodite.domain.RateLimit;
 import org.jboss.set.aphrodite.domain.Repository;
+import org.jboss.set.aphrodite.domain.spi.PullRequestHome;
 import org.jboss.set.aphrodite.repository.services.common.RepositoryType;
 
 public interface RepositoryService {
@@ -219,4 +220,11 @@ public interface RepositoryService {
      * @return RepositoryType
      */
     RepositoryType getRepositoryType();
+
+    /**
+     * Return the PullRequestHome service for this repository.
+     *
+     * @return Returns The PR home service for this repository.
+     */
+    PullRequestHome getPullRequestHome();
 }

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/PullRequest.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/PullRequest.java
@@ -66,6 +66,7 @@ public class PullRequest {
     private final MergeableState mergableState;
     private final Date mergedAt;
     private List<String> commits;
+    private PullRequestHome prHome;
 
     /**
      * @deprecated
@@ -115,6 +116,12 @@ public class PullRequest {
      */
     public List<String> getCommits() {
         return commits;
+    }
+
+    public PullRequest(String id, URL url, Repository repository, Codebase codebase, PullRequestState state, String title, String body,
+            boolean mergeable,boolean merged, MergeableState mergeableState, Date mergedAt, List<String> commits, PullRequestHome prHome) {
+        this(id, url, repository, codebase, state, title, body, mergeable, merged, mergeableState, mergedAt, commits);
+        this.prHome = prHome;
     }
 
     public String getId() {
@@ -310,40 +317,45 @@ public class PullRequest {
                 metas.getProperty("version"), metas.getProperty("branch"));
     }
 
+    private PullRequestHome getPullRequestHome() throws NameNotFoundException {
+        // return associated PullRequestHome or previous container instance
+        return prHome != null? prHome : Container.instance().lookup(PullRequestHome.class.getSimpleName(), (PullRequestHome.class));
+    }
+
     public List<PullRequest> findReferencedPullRequests() throws NameNotFoundException {
-        return Container.instance().lookup(PullRequestHome.class.getSimpleName(), (PullRequestHome.class)).findReferencedPullRequests(this);
+        return getPullRequestHome().findReferencedPullRequests(this);
     }
 
     public boolean addComment(String comment) throws NameNotFoundException {
-        return Container.instance().lookup(PullRequestHome.class.getSimpleName(), (PullRequestHome.class)).addComment(this, comment);
+        return getPullRequestHome().addComment(this, comment);
     }
 
     public List<Label> getLabels() throws NameNotFoundException {
-        return Container.instance().lookup(PullRequestHome.class.getSimpleName(), (PullRequestHome.class)).getLabels(this);
+        return getPullRequestHome().getLabels(this);
     }
 
     public boolean setLabels(List<Label> labels) throws NameNotFoundException {
-        return Container.instance().lookup(PullRequestHome.class.getSimpleName(), (PullRequestHome.class)).setLabels(this, labels);
+        return getPullRequestHome().setLabels(this, labels);
     }
 
     public boolean addLabel(Label label) throws NameNotFoundException {
-        return Container.instance().lookup(PullRequestHome.class.getSimpleName(), (PullRequestHome.class)).addLabel(this, label);
+        return getPullRequestHome().addLabel(this, label);
     }
 
     public boolean removeLabel(Label label) throws NameNotFoundException {
-        return Container.instance().lookup(PullRequestHome.class.getSimpleName(), (PullRequestHome.class)).removeLabel(this, label);
+        return getPullRequestHome().removeLabel(this, label);
     }
 
     public CommitStatus getCommitStatus() throws NameNotFoundException {
-        return Container.instance().lookup(PullRequestHome.class.getSimpleName(), (PullRequestHome.class)).getCommitStatus(this);
+        return getPullRequestHome().getCommitStatus(this);
     }
 
     public void approveOnPullRequest() throws NameNotFoundException {
-        Container.instance().lookup(PullRequestHome.class.getSimpleName(), (PullRequestHome.class)).approveOnPullRequest(this);
+        getPullRequestHome().approveOnPullRequest(this);
     }
 
     public void requestChangesOnPullRequest(String comment) throws NameNotFoundException {
-        Container.instance().lookup(PullRequestHome.class.getSimpleName(), (PullRequestHome.class)).requestChangesOnPullRequest(this, comment);
+        getPullRequestHome().requestChangesOnPullRequest(this, comment);
     }
 
     public boolean isMergeable() {

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/spi/PullRequestHome.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/spi/PullRequestHome.java
@@ -32,10 +32,12 @@ import org.jboss.set.aphrodite.domain.PullRequest;
 public interface PullRequestHome {
 
     /**
-     * Find all the referenced pull requests to the given pull request.
+     * Find the referenced pull requests to the given pull request in this PullRequestHome.
+     * In order to locate all the PRs in all the repos use the <em>aphrodite</em> method.
      *
      * @param pullRequest the <code>PullRequest</code> on which referenced pull requests are being searched
      * @return list of referenced pull requests.
+     * @see org.jboss.set.aphrodite.Aphrodite#findReferencedPullRequests(org.jboss.set.aphrodite.domain.PullRequest)
      */
     List<PullRequest> findReferencedPullRequests(PullRequest pullRequest);
 

--- a/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubWrapper.java
+++ b/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GitHubWrapper.java
@@ -44,6 +44,7 @@ import org.jboss.set.aphrodite.domain.PullRequest;
 import org.jboss.set.aphrodite.domain.PullRequestState;
 import org.jboss.set.aphrodite.domain.RateLimit;
 import org.jboss.set.aphrodite.domain.Repository;
+import org.jboss.set.aphrodite.domain.spi.PullRequestHome;
 import org.kohsuke.github.GHBranch;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHCompare;
@@ -68,13 +69,13 @@ class GitHubWrapper {
         return repo;
     }
 
-    List<PullRequest> toAphroditePullRequests(List<GHPullRequest> pullRequests) {
+    List<PullRequest> toAphroditePullRequests(List<GHPullRequest> pullRequests, PullRequestHome prHome) {
         return pullRequests.stream()
-                .map(this::pullRequestToPullRequest)
+                .map(pr -> this.pullRequestToPullRequest(pr, prHome))
                 .collect(Collectors.toList());
     }
 
-    PullRequest pullRequestToPullRequest(GHPullRequest pullRequest) {
+    PullRequest pullRequestToPullRequest(GHPullRequest pullRequest, PullRequestHome prHome) {
         try {
             final String id = Integer.toString(pullRequest.getNumber());
             final URL url = pullRequest.getHtmlUrl();
@@ -121,7 +122,7 @@ class GitHubWrapper {
                     }
                 }
             }
-            return new PullRequest(id, url, repo, codebase, state, title, body, mergeable, merged, mergeableState, mergedAt,commits);
+            return new PullRequest(id, url, repo, codebase, state, title, body, mergeable, merged, mergeableState, mergedAt, commits, prHome);
         } catch (IOException e) {
             Utils.logException(LOG, e);
             return null;

--- a/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GithubPullRequestHomeService.java
+++ b/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/GithubPullRequestHomeService.java
@@ -32,6 +32,7 @@ import org.apache.commons.logging.LogFactory;
 import org.jboss.set.aphrodite.Aphrodite;
 import org.jboss.set.aphrodite.common.Utils;
 import org.jboss.set.aphrodite.config.AphroditeConfig;
+import org.jboss.set.aphrodite.config.RepositoryConfig;
 import org.jboss.set.aphrodite.domain.CommitStatus;
 import org.jboss.set.aphrodite.domain.Label;
 import org.jboss.set.aphrodite.domain.PullRequest;
@@ -70,6 +71,11 @@ public class GithubPullRequestHomeService extends AbstractGithubService implemen
         this.init(configuration);
     }
 
+    public GithubPullRequestHomeService(RepositoryConfig config) {
+        super(RepositoryType.GITHUB);
+        this.init(config);
+    }
+
     @Override
     public List<PullRequest> findReferencedPullRequests(PullRequest pullRequest) {
         try {
@@ -100,7 +106,7 @@ public class GithubPullRequestHomeService extends AbstractGithubService implemen
         try {
             GHRepository repository = github.getRepository(repositoryId);
             GHPullRequest pullRequest = repository.getPullRequest(pullId);
-            return WRAPPER.pullRequestToPullRequest(pullRequest);
+            return WRAPPER.pullRequestToPullRequest(pullRequest, this);
         } catch (IOException e) {
             Utils.logException(LOG, "Unable to retrieve pull request from url " + url, e);
             return null;

--- a/gitlab/pom.xml
+++ b/gitlab/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright (c) 2020, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.set</groupId>
+        <artifactId>jboss-aphrodite-parent</artifactId>
+        <version>0.7.10.Final-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jboss-aphrodite-gitlab</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.set</groupId>
+            <artifactId>jboss-aphrodite-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.gitlab4j</groupId>
+            <artifactId>gitlab4j-api</artifactId>
+            <version>${org.gitlab4j.gitlab4j-api.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/gitlab/src/main/java/org/jboss/set/aphrodite/repository/services/gitlab/GitLabPullRequestHomeService.java
+++ b/gitlab/src/main/java/org/jboss/set/aphrodite/repository/services/gitlab/GitLabPullRequestHomeService.java
@@ -1,0 +1,271 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.set.aphrodite.repository.services.gitlab;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.gitlab4j.api.GitLabApi;
+import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.models.CommitStatusFilter;
+import org.gitlab4j.api.models.MergeRequest;
+import org.gitlab4j.api.models.MergeRequestParams;
+import org.jboss.set.aphrodite.common.Utils;
+import org.jboss.set.aphrodite.domain.CommitStatus;
+import org.jboss.set.aphrodite.domain.Label;
+import org.jboss.set.aphrodite.domain.PullRequest;
+import org.jboss.set.aphrodite.domain.spi.PullRequestHome;
+import org.jboss.set.aphrodite.spi.NotFoundException;
+
+/**
+ * <p>PullRequestHome implementation for the gitlab repository</p>
+ *
+ * @author rmartinc
+ */
+public class GitLabPullRequestHomeService implements PullRequestHome {
+
+    private static final Log LOG = LogFactory.getLog(GitLabPullRequestHomeService.class);
+
+    private final GitLabApi gitLabApi;
+    private final GitLabRepositoryService gitLabRepo;
+    private final Pattern prPattern;
+
+    /**
+     * Constructor using the the api.
+     * @param gitLabApi The api to query the server
+     * @param gitLabRepo The gitlab repository
+     */
+    public GitLabPullRequestHomeService(GitLabApi gitLabApi, GitLabRepositoryService gitLabRepo) {
+        this.gitLabApi = gitLabApi;
+        this.gitLabRepo = gitLabRepo;
+        // create a pattern to locate the PRs in the description to this GitLab repository
+        String patternString = ".*" + Pattern.quote(gitLabRepo.getBaseUrl().getHost()) + ".*?/([a-zA-Z_0-9-]*)/([a-zA-Z_0-9-]*)/-?/?merge_requests/(\\d+)";
+        prPattern = Pattern.compile(patternString, Pattern.CASE_INSENSITIVE);
+    }
+
+    // comments
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean addComment(PullRequest pullRequest, String comment) {
+        String repoId = GitLabUtils.getProjectIdFromURL(pullRequest.getRepository().getURL());
+        int mergeId = Integer.parseInt(pullRequest.getId());
+        try {
+            gitLabApi.getDiscussionsApi().createMergeRequestDiscussion(repoId, mergeId, comment, new Date(), null, null);
+            return true;
+        } catch (GitLabApiException e) {
+            LOG.debug("addComment error", e);
+            return false;
+        }
+    }
+
+    // labels
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Label> getLabels(PullRequest pullRequest) {
+        String repoId = GitLabUtils.getProjectIdFromURL(pullRequest.getRepository().getURL());
+        int mergeId = Integer.parseInt(pullRequest.getId());
+        try {
+            MergeRequest merge = gitLabApi.getMergeRequestApi().getMergeRequest(repoId, mergeId);
+            List<String> labels = merge.getLabels();
+            List<Label> res = new ArrayList<>(labels.size());
+            for (String name : labels) {
+                org.gitlab4j.api.models.Label l = gitLabApi.getLabelsApi().getProjectLabel(repoId, name);
+                res.add(GitLabUtils.toLabel(l, pullRequest.getRepository().getURL()));
+            }
+            return res;
+        } catch (GitLabApiException e) {
+            Utils.logException(LOG, "Error getting the labels", e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean setLabels(PullRequest pullRequest, List<Label> labels) {
+        String repoId = GitLabUtils.getProjectIdFromURL(pullRequest.getRepository().getURL());
+        int mergeId = Integer.parseInt(pullRequest.getId());
+        try {
+            List<String> names = labels.stream().map(Label::getName).collect(Collectors.toList());
+            gitLabApi.getMergeRequestApi().updateMergeRequest(repoId, mergeId, new MergeRequestParams().withLabels(names));
+            return true;
+        } catch (GitLabApiException e) {
+            Utils.logException(LOG, "Error setting the labels", e);
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean addLabel(PullRequest pullRequest, Label label) {
+        String repoId = GitLabUtils.getProjectIdFromURL(pullRequest.getRepository().getURL());
+        int mergeId = Integer.parseInt(pullRequest.getId());
+        try {
+            MergeRequest merge = gitLabApi.getMergeRequestApi().getMergeRequest(repoId, mergeId);
+            List<String> names = merge.getLabels();
+            if (!names.contains(label.getName())) {
+                names.add(label.getName());
+                gitLabApi.getMergeRequestApi().updateMergeRequest(repoId, mergeId, new MergeRequestParams().withLabels(names));
+                return true;
+            }
+        } catch (GitLabApiException e) {
+            Utils.logException(LOG, "Error adding the label", e);
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean removeLabel(PullRequest pullRequest, Label label) {
+        String repoId = GitLabUtils.getProjectIdFromURL(pullRequest.getRepository().getURL());
+        int mergeId = Integer.parseInt(pullRequest.getId());
+        try {
+            MergeRequest merge = gitLabApi.getMergeRequestApi().getMergeRequest(repoId, mergeId);
+            List<String> names = merge.getLabels();
+            if (names.remove(label.getName())) {
+                gitLabApi.getMergeRequestApi().updateMergeRequest(repoId, mergeId, new MergeRequestParams().withLabels(names));
+                return true;
+            }
+        } catch (GitLabApiException e) {
+            Utils.logException(LOG, "Error removing the label", e);
+        }
+        return false;
+    }
+
+    // Pull Requests
+
+    private List<URL> getPRFromDescription(URL url, String content) throws MalformedURLException, URISyntaxException {
+        Matcher gitlabMatcher = prPattern.matcher(content);
+        List<URL> relatedPullRequests = new ArrayList<>();
+        while (gitlabMatcher.find()) {
+            if (gitlabMatcher.groupCount() == 3) {
+                URL relatedPullRequest = new URI(gitLabRepo.getBaseUrl() + gitlabMatcher.group(1) + "/"
+                        + gitlabMatcher.group(2) + "/-/merge_requests/" + gitlabMatcher.group(3)).toURL();
+                relatedPullRequests.add(relatedPullRequest);
+            }
+        }
+        return relatedPullRequests;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<PullRequest> findReferencedPullRequests(PullRequest pullRequest) {
+        try {
+            List<URL> urls = getPRFromDescription(pullRequest.getURL(), pullRequest.getBody());
+            List<PullRequest> related = new ArrayList<>();
+            for (URL url : urls) {
+                if (GitLabUtils.urlIsInRepo(url, pullRequest.getRepository().getURL())) {
+                    try {
+                        related.add(gitLabRepo.getPullRequest(url));
+                    } catch (NotFoundException e) {
+                        Utils.logException(LOG, "Unable to retrieve url '" + url + "' referenced in the pull request.", e);
+                    }
+                }
+            }
+            return related;
+        } catch (MalformedURLException | URISyntaxException e) {
+            Utils.logException(LOG, "something went wrong while trying to get related pull requests to " + pullRequest.getURL(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CommitStatus getCommitStatus(PullRequest pullRequest) {
+        String repoId = GitLabUtils.getProjectIdFromURL(pullRequest.getRepository().getURL());
+        int mergeId = Integer.parseInt(pullRequest.getId());
+        try {
+            List<String> commits = pullRequest.getCommits();
+            if (commits != null && !commits.isEmpty()) {
+                // get the last commit
+                String sha = commits.get(commits.size() - 1);
+                CommitStatusFilter filter = new CommitStatusFilter().withAll(true);
+                List<org.gitlab4j.api.models.CommitStatus> statuses = gitLabApi.getCommitsApi().getCommitStatuses(repoId, sha, filter);
+                // TODO: there are no test suite here so what to do here, for the moment returning one (it's always empty right now)
+                if (!statuses.isEmpty()) {
+                    return GitLabUtils.toCommitStatus(statuses.iterator().next().getStatus());
+                }
+            }
+            return CommitStatus.UNKNOWN;
+        } catch (GitLabApiException e) {
+            Utils.logException(LOG, e);
+            return CommitStatus.UNKNOWN;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void approveOnPullRequest(PullRequest pullRequest) {
+        // Approvals are only in gitlab enterprise (gitlab.cee.redhat.com has no approvals)
+        String repoId = GitLabUtils.getProjectIdFromURL(pullRequest.getRepository().getURL());
+        int mergeId = Integer.parseInt(pullRequest.getId());
+        try {
+            // TODO: not tested as gitlab.cee has no approvals
+            gitLabApi.getMergeRequestApi().approveMergeRequest(repoId, mergeId, null);
+        } catch (GitLabApiException e) {
+            LOG.error("Error approving the request", e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void requestChangesOnPullRequest(PullRequest pullRequest, String body) {
+        // Approvals are only in gitlab enterprise (gitlab.cee.redhat.com has no approvals)
+        String repoId = GitLabUtils.getProjectIdFromURL(pullRequest.getRepository().getURL());
+        int mergeId = Integer.parseInt(pullRequest.getId());
+        try {
+            // TODO: not tested as gitlab.cee has no approvals
+            gitLabApi.getMergeRequestApi().unapproveMergeRequest(repoId, mergeId);
+        } catch (GitLabApiException e) {
+            Utils.logException(LOG, e);
+        }
+    }
+}

--- a/gitlab/src/main/java/org/jboss/set/aphrodite/repository/services/gitlab/GitLabRepositoryService.java
+++ b/gitlab/src/main/java/org/jboss/set/aphrodite/repository/services/gitlab/GitLabRepositoryService.java
@@ -1,0 +1,348 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.set.aphrodite.repository.services.gitlab;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.gitlab4j.api.Constants;
+import org.gitlab4j.api.GitLabApi;
+import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.models.AccessLevel;
+import org.gitlab4j.api.models.Branch;
+import org.gitlab4j.api.models.Commit;
+import org.gitlab4j.api.models.Member;
+import org.gitlab4j.api.models.MergeRequest;
+import org.gitlab4j.api.models.MergeRequestFilter;
+import org.gitlab4j.api.models.Project;
+import org.gitlab4j.api.models.User;
+import org.jboss.set.aphrodite.common.Utils;
+import org.jboss.set.aphrodite.config.RepositoryConfig;
+import org.jboss.set.aphrodite.domain.Codebase;
+import org.jboss.set.aphrodite.domain.CommitStatus;
+import org.jboss.set.aphrodite.domain.Issue;
+import org.jboss.set.aphrodite.domain.Label;
+import org.jboss.set.aphrodite.domain.PullRequest;
+import org.jboss.set.aphrodite.domain.PullRequestState;
+import org.jboss.set.aphrodite.domain.RateLimit;
+import org.jboss.set.aphrodite.domain.Repository;
+import org.jboss.set.aphrodite.domain.spi.PullRequestHome;
+import org.jboss.set.aphrodite.repository.services.common.AbstractRepositoryService;
+import org.jboss.set.aphrodite.repository.services.common.RepositoryType;
+import org.jboss.set.aphrodite.spi.NotFoundException;
+import org.jboss.set.aphrodite.spi.RepositoryService;
+
+/**
+ * <p>Repository service for gitlab. It uses the <a href="https://github.com/gitlab4j/gitlab4j-api">
+ * gitlabapi</a> to communicate with the server.</p>
+ *
+ * @author rmartinc
+ */
+public class GitLabRepositoryService extends AbstractRepositoryService implements RepositoryService {
+
+    private static final Log LOG = LogFactory.getLog(GitLabRepositoryService.class);
+
+    private GitLabApi gitLabApi;
+    private GitLabPullRequestHomeService prHome;
+
+    /**
+     * Empty constructor.
+     */
+    public GitLabRepositoryService() {
+        super(RepositoryType.GITLAB);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean init(RepositoryConfig config) {
+        boolean result = super.init(config);
+        LOG.debug("Initializing GitLab repository " + config.getUrl());
+        if (result) {
+            try {
+                // TODO: Try using username/password too
+                gitLabApi = new GitLabApi(config.getUrl(), config.getPassword());
+                // get the current user and check the name
+                User user = gitLabApi.getUserApi().getCurrentUser();
+                if (user.getUsername().equalsIgnoreCase(config.getUsername())) {
+                    this.prHome = new GitLabPullRequestHomeService(gitLabApi, this);
+                    result = true;
+                } else {
+                    LOG.warn("Username is different to the configuration one " + user.getName());
+                    result = false;
+                }
+            } catch (GitLabApiException e) {
+                LOG.warn("Error initializing gitlab " + config.getUrl(), e);
+                result = false;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Log getLog() {
+        return LOG;
+    }
+
+    // repository
+
+    private Repository getRepository(String repoId) throws NotFoundException {
+        try {
+            List<Branch> branches = gitLabApi.getRepositoryApi().getBranches(repoId);
+            Repository repo = new Repository(new URL(baseUrl + repoId));
+            List<Codebase> branchNames = new ArrayList<>(branches.size());
+            for (Branch b : branches) {
+                branchNames.add(new Codebase(b.getName()));
+            }
+            repo.getCodebases().addAll(branchNames);
+            return repo;
+        } catch (GitLabApiException|MalformedURLException e) {
+            throw new NotFoundException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Repository getRepository(URL url) throws NotFoundException {
+        GitLabUtils.checkIsInRepo(url, baseUrl);
+
+        String repoId = GitLabUtils.getProjectIdFromURL(url);
+        if (repoId == null) {
+            throw new NotFoundException("Repository " + url + " cannot be found.");
+        }
+        return getRepository(repoId);
+    }
+
+    // Pull Request
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PullRequest getPullRequest(URL url) throws NotFoundException {
+        GitLabUtils.checkIsInRepo(url, baseUrl);
+
+        String[] res = GitLabUtils.getProjectIdAndLastFieldFromURL(url);
+        if (res != null && res.length == 2) {
+            try {
+                String repoId = res[0];
+                int mergeId = Integer.parseInt(res[1]);
+                Repository repo = getRepository(repoId);
+                MergeRequest merge = gitLabApi.getMergeRequestApi().getMergeRequest(repoId, mergeId);
+                List<Commit> commits = gitLabApi.getMergeRequestApi().getCommits(repoId, mergeId);
+                return GitLabUtils.toPullRequest(merge, commits, url, repo, prHome);
+            } catch (GitLabApiException e) {
+                throw new NotFoundException(e);
+            }
+        }
+        throw new NotFoundException("Merge Request " + url + " cannot be found.");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<PullRequest> getPullRequestsByState(Repository repository, PullRequestState state) throws NotFoundException {
+        String repoId = GitLabUtils.getProjectIdFromURL(repository.getURL());
+        try {
+            Project project = gitLabApi.getProjectApi().getProject(repoId);
+            MergeRequestFilter filter = new MergeRequestFilter();
+            filter.setState(Constants.MergeRequestState.OPENED);
+            filter.setProjectId(project.getId());
+            List<MergeRequest> merges = gitLabApi.getMergeRequestApi().getMergeRequests(filter);
+            List<PullRequest> prs = new ArrayList<>(merges.size());
+            for (MergeRequest merge : merges) {
+                List<Commit> commits = gitLabApi.getMergeRequestApi().getCommits(repoId, merge.getIid());
+                prs.add(GitLabUtils.toPullRequest(merge, commits, new URL(repository.getURL() + "/merge_requests/" + merge.getIid()), repository, prHome));
+            }
+            return prs;
+        } catch (GitLabApiException|MalformedURLException e) {
+            throw new NotFoundException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Deprecated
+    public List<PullRequest> findPullRequestsRelatedTo(PullRequest pullRequest) {
+        return prHome.findReferencedPullRequests(pullRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Deprecated
+    public List<PullRequest> getPullRequestsAssociatedWith(Issue issue) throws NotFoundException {
+        // not implementeed in github
+        Utils.logException(LOG, new UnsupportedOperationException("Not yet implemented."));
+        return Collections.emptyList();
+    }
+
+    // Comments
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Deprecated
+    public void addCommentToPullRequest(PullRequest pullRequest, String comment) throws NotFoundException {
+        prHome.addComment(pullRequest, comment);
+    }
+
+    // Labels methods
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasModifiableLabels(Repository repository) throws NotFoundException {
+        String repoId = GitLabUtils.getProjectIdFromURL(repository.getURL());
+        try {
+            User user = gitLabApi.getUserApi().getCurrentUser();
+            Member member = gitLabApi.getProjectApi().getMember(repoId, user.getId());
+            return member.getAccessLevel().ordinal() >= AccessLevel.DEVELOPER.ordinal();
+        } catch (GitLabApiException e) {
+            LOG.info("hasModifiableLabels error", e);
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Label> getLabelsFromRepository(Repository repository) throws NotFoundException {
+        String repoId = GitLabUtils.getProjectIdFromURL(repository.getURL());
+        try {
+            List<org.gitlab4j.api.models.Label> labels = gitLabApi.getLabelsApi().getProjectLabels(repoId);
+            List<Label> res = new ArrayList<>(labels.size());
+            for (org.gitlab4j.api.models.Label l : labels) {
+                res.add(GitLabUtils.toLabel(l, repository.getURL()));
+            }
+            return res;
+        } catch (GitLabApiException e) {
+            throw new NotFoundException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Deprecated
+    public List<Label> getLabelsFromPullRequest(PullRequest pullRequest) throws NotFoundException {
+        return prHome.getLabels(pullRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Deprecated
+    public void setLabelsToPullRequest(PullRequest pullRequest, List<Label> labels) throws NotFoundException {
+        prHome.setLabels(pullRequest, labels);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Deprecated
+    public void addLabelToPullRequest(PullRequest pullRequest, String labelName) throws NotFoundException {
+        prHome.addLabel(pullRequest, new Label(labelName));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Deprecated
+    public void removeLabelFromPullRequest(PullRequest pullRequest, String labelName) throws NotFoundException {
+        prHome.removeLabel(pullRequest, new Label(labelName));
+    }
+
+    // commit status
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Deprecated
+    public CommitStatus getCommitStatusFromPullRequest(PullRequest pullRequest) throws NotFoundException {
+        return prHome.getCommitStatus(pullRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean repositoryAccessable(URL url) {
+        try {
+            String repoId = GitLabUtils.getProjectIdFromURL(url);
+            boolean res = GitLabUtils.urlIsInRepo(url, baseUrl) &&
+                gitLabApi.getRepositoryApi().getBranches(repoId) != null;
+            return res;
+        } catch (GitLabApiException e) {
+            LOG.info("Invalid repo url " + url, e);
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RateLimit getRateLimit() throws NotFoundException {
+        // TODO: nothing here
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RepositoryType getRepositoryType() {
+        return REPOSITORY_TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PullRequestHome getPullRequestHome() {
+        return prHome;
+    }
+}

--- a/gitlab/src/main/java/org/jboss/set/aphrodite/repository/services/gitlab/GitLabUtils.java
+++ b/gitlab/src/main/java/org/jboss/set/aphrodite/repository/services/gitlab/GitLabUtils.java
@@ -1,0 +1,217 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.set.aphrodite.repository.services.gitlab;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.gitlab4j.api.models.Commit;
+import org.gitlab4j.api.models.MergeRequest;
+import org.jboss.set.aphrodite.domain.Codebase;
+import org.jboss.set.aphrodite.domain.CommitStatus;
+import org.jboss.set.aphrodite.domain.Label;
+import org.jboss.set.aphrodite.domain.MergeableState;
+import org.jboss.set.aphrodite.domain.PullRequest;
+import org.jboss.set.aphrodite.domain.PullRequestState;
+import org.jboss.set.aphrodite.domain.Repository;
+import org.jboss.set.aphrodite.domain.spi.PullRequestHome;
+import org.jboss.set.aphrodite.spi.NotFoundException;
+
+/**
+ * <p>Utility methods for the gitlab repository.</p>
+ *
+ * @author rmartinc
+ */
+public class GitLabUtils {
+
+    /**
+     * Return the project id from a gitlab repo URL. The URL is in the form:
+     * <em>http(s)://hostname:port/group/project</em> and the method returns
+     * the part <em>group/project</em>.
+     *
+     * @param url The gitab repo URL
+     * @return The project id in the form <em>group/project</em>
+     */
+    public static String getProjectIdFromURL(URL url) {
+        String[] parts = getProjectIdAndLastFieldFromURL(url);
+        if (parts != null) {
+            return parts[0];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Return the projectId and the last path part in a two sized array. The
+     * first string will be the project ID and the second the last path. For the
+     * URL <em>http(s)://hostname:port/group/project/.../32</em> the method
+     * returns the array <em>["group/project", "32"]</em>.
+     * @param url The URL to parse
+     * @return The array with two parts or null
+     */
+    public static String[] getProjectIdAndLastFieldFromURL(URL url) {
+        try {
+            url = url.toURI().normalize().toURL();
+            String[] path = url.getPath().split("/");
+            String owner = null, project = null;
+            for (int i = 0; i < path.length && (owner == null || project == null); i++) {
+                if (!path[i].isEmpty()) {
+                    if (owner == null) {
+                        owner = path[i];
+                    } else {
+                        project = path[i];
+                    }
+                }
+            }
+            String mergeId = null;
+            for (int i = path.length - 1; i > 0 && mergeId == null; i--) {
+                if (!path[i].isEmpty()) {
+                    mergeId = path[i];
+                }
+            }
+            if (owner != null && project != null && mergeId != null) {
+                return new String[]{owner + "/" + project, mergeId};
+            } else {
+                return null;
+            }
+        } catch (MalformedURLException | URISyntaxException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Method to check if an URL is in the repo URL. The method checks the
+     * protocol, hostname and port of both URLS.
+     * @param url The URL to check
+     * @param repoUrl The repository URL
+     * @return true if the URL is in the same origin than the repo URL
+     */
+    public static boolean urlIsInRepo(URL url, URL repoUrl) {
+        Objects.requireNonNull(url);
+        return url.getProtocol().equals(repoUrl.getProtocol()) &&
+                url.getHost().equalsIgnoreCase(repoUrl.getHost()) &&
+                url.getPort() == repoUrl.getPort();
+    }
+
+    /**
+     * If the url is not in the repoURL a NotFoundException is thrown.
+     *
+     * @param url The URL to check
+     * @param repoUrl The repository URL
+     * @throws NotFoundException If url is not in repoUrl
+     */
+    public static void checkIsInRepo(URL url, URL repoUrl) throws NotFoundException {
+        if (!urlIsInRepo(url, repoUrl)) {
+            throw new NotFoundException("Repository " + url + " cannot be found as it is not hosted on this server.");
+        }
+    }
+
+    /**
+     * Converts gitlab state into a PullRequestState
+     *
+     * @param state The gitlab state
+     * @return The aphrodite state
+     */
+    public static PullRequestState toPullRequestState(String state) {
+        switch (state) {
+            case "opened":
+                return PullRequestState.OPEN;
+            case "closed":
+                return PullRequestState.CLOSED;
+            default:
+                return PullRequestState.UNDEFINED;
+        }
+    }
+
+    /**
+     * Returns if the merge status is a mergeable aphrodite status.
+     *
+     * @param mergeStatus The gitlab merge status
+     * @return true is it's mergeable
+     */
+    public static boolean toMergeable(String mergeStatus) {
+        return "can_be_merged".equals(mergeStatus);
+    }
+
+    /**
+     * Converts a gitlan commit status into an aphrodite commit status.
+     *
+     * @param statusValue The gitlab status of the commit
+     * @return The equivalent status in aphrodite
+     */
+    public static CommitStatus toCommitStatus(String statusValue) {
+        // pending, running, success, failed, canceled
+        switch (statusValue) {
+            case "pending":
+                return CommitStatus.PENDING;
+            case "running":
+                return CommitStatus.PENDING;
+            case "success":
+                return CommitStatus.SUCCESS;
+            case "failed":
+                return CommitStatus.FAILURE;
+            default:
+                return CommitStatus.UNKNOWN;
+        }
+    }
+
+    /**
+     * Converts a gitlab merge object into an aphrodite pull request.
+     *
+     * @param m The gilab merge object
+     * @param commits The commits of the merge request
+     * @param url The URL for the merge
+     * @param repo The repository of the merge
+     * @param prHome The pull request home to use in the or
+     * @return The aphrodite PullRequesy
+     */
+    public static PullRequest toPullRequest(MergeRequest m, List<Commit> commits, URL url, Repository repo, PullRequestHome prHome) {
+        return new PullRequest(m.getIid().toString(),
+                url,
+                repo,  // repo
+                new Codebase(m.getTargetBranch()), // codebase
+                toPullRequestState(m.getState()), // state
+                m.getTitle(), // title
+                m.getDescription(), // body
+                toMergeable(m.getMergeStatus()), // mergeable
+                m.getMergedAt() != null, // merged
+                MergeableState.UNKNOWN, //merge state
+                m.getMergedAt(),
+                commits.stream().map(Commit::getId).collect(Collectors.toList()),
+                prHome);
+    }
+
+    /**
+     * Converts a gitlab label into an aphrodite one.
+     *
+     * @param l The gitlab label
+     * @param repoUrl The label URL
+     * @return The aphrodite label
+     */
+    public static Label toLabel(org.gitlab4j.api.models.Label l, URL repoUrl) {
+        return new Label(l.getId().toString(), l.getColor(), l.getName(), repoUrl + "/labels/" + l.getName());
+    }
+}

--- a/gitlab/src/main/resources/META-INF/services/org.jboss.set.aphrodite.spi.RepositoryService
+++ b/gitlab/src/main/resources/META-INF/services/org.jboss.set.aphrodite.spi.RepositoryService
@@ -1,0 +1,1 @@
+org.jboss.set.aphrodite.repository.services.gitlab.GitLabRepositoryService

--- a/gitlab/src/test/java/org/jboss/set/aphrodite/repository/services/gitlab/GitLabTest.java
+++ b/gitlab/src/test/java/org/jboss/set/aphrodite/repository/services/gitlab/GitLabTest.java
@@ -1,0 +1,155 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.set.aphrodite.repository.services.gitlab;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.set.aphrodite.Aphrodite;
+import org.jboss.set.aphrodite.config.AphroditeConfig;
+import org.jboss.set.aphrodite.config.IssueTrackerConfig;
+import org.jboss.set.aphrodite.config.RepositoryConfig;
+import org.jboss.set.aphrodite.config.StreamConfig;
+import org.jboss.set.aphrodite.domain.Label;
+import org.jboss.set.aphrodite.domain.PullRequest;
+import org.jboss.set.aphrodite.domain.PullRequestState;
+import org.jboss.set.aphrodite.domain.Repository;
+import org.jboss.set.aphrodite.repository.services.common.RepositoryType;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * <p>Test for gitlab that is skipped when username or password are not
+ * available.</p>
+ *
+ * @author rmartinc
+ */
+public class GitLabTest {
+
+    private static Aphrodite aphrodite;
+    private static final String REPO_URL = "https://gitlab.cee.redhat.com";
+    private static final String PROJECT_URL = REPO_URL + "/rmartinc/test";
+    private static final String PULL_REQUEST_ID = "1";
+    private static final String PULL_REQUEST_URL = PROJECT_URL + "/-/merge_requests/" + PULL_REQUEST_ID;
+    private static final String PULL_REQUEST_BRANCH = "master";
+
+    // empty username to disable the test (only locally executed)
+    private static final String USERNAME = "";
+    private static final String PASSWORD = "";
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        Assume.assumeTrue(!USERNAME.isEmpty() && !PASSWORD.isEmpty());
+        // create the aphrodite instance with only the gitlab repository
+        RepositoryConfig gitLabConfig = new RepositoryConfig(REPO_URL, USERNAME, PASSWORD, RepositoryType.GITLAB);
+        List<RepositoryConfig> repositoryConfigs = new ArrayList<>();
+        repositoryConfigs.add(gitLabConfig);
+        List<IssueTrackerConfig> issueTrackerConfigs = new ArrayList<>();
+        List<StreamConfig> streamConfigs = new ArrayList<>();
+        AphroditeConfig config = new AphroditeConfig(issueTrackerConfigs, repositoryConfigs, streamConfigs);
+        aphrodite = Aphrodite.instance(config);
+    }
+
+    @Test
+    public void testGetRepository() throws Exception {
+        URL url = new URL(PROJECT_URL);
+        Repository repo = aphrodite.getRepository(url);
+        Assert.assertEquals(url, repo.getURL());
+        Assert.assertTrue(repo.getCodebases().size() >= 1);
+        Assert.assertTrue(repo.getCodebases().stream().filter(n -> n.getName().equals(PULL_REQUEST_BRANCH)).findFirst().isPresent());
+        Assert.assertTrue(aphrodite.isRepositoryLabelsModifiable(repo));
+        List<PullRequest> list = aphrodite.getPullRequestsByState(repo, PullRequestState.OPEN);
+        Assert.assertTrue(list.size() > 0);
+    }
+
+    @Test
+    public void testGetPullRequest() throws Exception {
+        URL url = new URL(PULL_REQUEST_URL);
+        PullRequest pr = aphrodite.getPullRequest(url);
+        Assert.assertNotNull(pr);
+        Assert.assertEquals(url, pr.getURL());
+        Assert.assertEquals(PULL_REQUEST_ID, pr.getId());
+        Assert.assertEquals(PULL_REQUEST_BRANCH, pr.getCodebase().getName());
+        Assert.assertFalse(pr.getCommits().isEmpty());
+        Assert.assertTrue(pr.findReferencedPullRequests().size() >= 1);
+    }
+
+    private Label getMissingLabel(List<Label> repoLabels, List<Label> prLabels) {
+        for (Label repoLabel : repoLabels) {
+            boolean found = false;
+            for (Label prLabel : prLabels) {
+                if (prLabel.getName().equals(repoLabel.getName())) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                return repoLabel;
+            }
+        }
+        return null;
+    }
+
+    @Test
+    public void testLabels() throws Exception {
+        URL url = new URL(PULL_REQUEST_URL);
+        PullRequest pr = aphrodite.getPullRequest(url);
+        Assert.assertNotNull(pr);
+        Repository repo = aphrodite.getRepository(url);
+        Assert.assertNotNull(repo);
+
+        List<Label> repoLabels = aphrodite.getLabelsFromRepository(repo);
+        Assert.assertTrue(repoLabels.size() > 0);
+        List<Label> prLabels = pr.getLabels();
+        Label toAdd = getMissingLabel(repoLabels, prLabels);
+
+        pr.addLabel(toAdd);
+        List<Label> newPrLabels = pr.getLabels();
+        Assert.assertEquals(prLabels.size() + 1, newPrLabels.size());
+        Assert.assertTrue(newPrLabels.stream().filter(l -> l.getName().equals(toAdd.getName())).findFirst().isPresent());
+
+        pr.removeLabel(toAdd);
+        newPrLabels = pr.getLabels();
+        Assert.assertEquals(prLabels.size(), newPrLabels.size());
+        Assert.assertTrue(!newPrLabels.stream().filter(l -> l.getName().equals(toAdd.getName())).findFirst().isPresent());
+
+        pr.setLabels(Collections.singletonList(toAdd));
+        newPrLabels = pr.getLabels();
+        Assert.assertEquals(1, newPrLabels.size());
+        Assert.assertTrue(newPrLabels.iterator().next().getName().equals(toAdd.getName()));
+
+        pr.setLabels(prLabels);
+        newPrLabels = pr.getLabels();
+        Assert.assertEquals(prLabels.size(), newPrLabels.size());
+    }
+
+    @Test
+    public void testComment() throws Exception {
+        URL url = new URL(PULL_REQUEST_URL);
+        PullRequest pr = aphrodite.getPullRequest(url);
+        Assert.assertNotNull(pr);
+        pr.addComment("comment added by the test-suite");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <module>container</module>
         <module>domain</module>
         <module>github</module>
+        <module>gitlab</module>
         <module>jira</module>
         <module>simplecontainer</module>
         <module>test</module>
@@ -106,6 +107,7 @@
         <commons.logging.version>1.1.3</commons.logging.version>
         <javax.json.version>1.0.4</javax.json.version>
         <junit.version>4.12</junit.version>
+        <org.gitlab4j.gitlab4j-api.version>4.14.30</org.gitlab4j.gitlab4j-api.version>
         <org.mockito.version>1.10.19</org.mockito.version>
         <org.wildfly.checkstyle-config.version>1.0.4.Final</org.wildfly.checkstyle-config.version>
         <org.kohsuke.github-api.version>1.111</org.kohsuke.github-api.version>


### PR DESCRIPTION
Issue: https://projects.engineering.redhat.com/browse/SET-238

Used [gitlab4j-api](https://github.com/gitlab4j/gitlab4j-api/) to connect to the gitlab server. I needed to re-think the PullRequestHome, now there can be more than one (github and gitlab). So I decided to add the PullRequestHome to the PullRequest (added from the repository), the previous Container instance is used for backwards compatibility (although I have also change the github implementation to add the github impl of the PullRequestHome).