### PR TITLE
correct jira duplicate id number.

### DIFF
--- a/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssueResolution.java
+++ b/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraIssueResolution.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jboss.set.aphrodite.issue.trackers.jira;
 
 public enum JiraIssueResolution {
@@ -16,8 +32,8 @@ public enum JiraIssueResolution {
     UNRESOLVED(0,"UNRESOLVED"),
     WONTDO(10000, "WON'T DO"),
     CANNOT_REPRODUCE(10002, "CANNOT REPRODUCE"),
-    DUPLICATE(10200, "DUPLICATE"),
-    EXPLAINED(10300, "EXPLAINED");
+    EXPLAINED(10300, "EXPLAINED"),
+    DUPLICATE(10700, "DUPLICATE");
 
     private long id;
     private String label;


### PR DESCRIPTION
server.log shows `10:04:55,653 WARN  [org.jboss.set.aphrodite.issue.trackers.jira.JiraIssueTracker] (pool-13-thread-1) Could not convert issue resolution: Duplicate (10700) for issue: JBEAP-18731`

so it seems that the duplicate jira id in JiraIssueResolution is wrong.