### PR TITLE
Upgrade JUnit to 4.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <!-- Dependency versions, please keep alphabetically -->
         <commons.logging.version>1.1.3</commons.logging.version>
         <javax.json.version>1.0.4</javax.json.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.1</junit.version>
         <org.gitlab4j.gitlab4j-api.version>4.14.30</org.gitlab4j.gitlab4j-api.version>
         <org.mockito.version>1.10.19</org.mockito.version>
         <org.wildfly.checkstyle-config.version>1.0.4.Final</org.wildfly.checkstyle-config.version>


### PR DESCRIPTION
Fix low severity CVE-2020-15250 TemporaryFolder on unix-like systems does not limit access to created files
https://github.com/advisories/GHSA-269g-pwp5-87pp