### PR TITLE
Upgrade github-api to 1.119 and okhttp to 3.14.9

### DIFF
--- a/github/pom.xml
+++ b/github/pom.xml
@@ -33,7 +33,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.squareup.okhttp</groupId>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-urlconnection</artifactId>
             <version>${com.squareup.okhttp.okhttp-urlconnection.version}</version>
         </dependency>

--- a/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/AbstractGithubService.java
+++ b/github/src/main/java/org/jboss/set/aphrodite/repository/services/github/AbstractGithubService.java
@@ -28,11 +28,10 @@ import org.jboss.set.aphrodite.repository.services.common.RepositoryType;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
-import org.kohsuke.github.extras.OkHttpConnector;
+import org.kohsuke.github.extras.okhttp3.OkHttpConnector;
 
-import com.squareup.okhttp.Cache;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.OkUrlFactory;
+import okhttp3.Cache;
+import okhttp3.OkHttpClient;
 
 /**
  * @author wangc
@@ -98,7 +97,7 @@ public abstract class AbstractGithubService extends AbstractRepositoryService {
                 // oauthAccessToken here, if you use text password, call .withPassword()
                 github = new GitHubBuilder()
                         .withOAuthToken(config.getPassword(), config.getUsername())
-                        .withConnector(new OkHttpConnector(new OkUrlFactory(new OkHttpClient().setCache(cache))))
+                        .withConnector(new OkHttpConnector(new OkHttpClient.Builder().cache(cache).build()))
                         .build();
 
             }

--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,8 @@
         <org.gitlab4j.gitlab4j-api.version>4.14.30</org.gitlab4j.gitlab4j-api.version>
         <org.mockito.version>1.10.19</org.mockito.version>
         <org.wildfly.checkstyle-config.version>1.0.4.Final</org.wildfly.checkstyle-config.version>
-        <org.kohsuke.github-api.version>1.116</org.kohsuke.github-api.version>
-        <com.squareup.okhttp.okhttp-urlconnection.version>2.7.5</com.squareup.okhttp.okhttp-urlconnection.version>
+        <org.kohsuke.github-api.version>1.119</org.kohsuke.github-api.version>
+        <com.squareup.okhttp.okhttp-urlconnection.version>3.14.9</com.squareup.okhttp.okhttp-urlconnection.version>
     </properties>
 
 


### PR DESCRIPTION
github-api has deprecated okhttp support for 2.x. This upgrades it to okhttp3 v3.14.x as recommended in https://github.com/hub4j/github-api/issues/997

~~Also I am going to upgrade github-api to 1.118 for the mentioned issue in https://github.com/hub4j/github-api/issues/997 once it's released in the upcoming future~~

Edit: github-api 1.119 has been released, so I update this to 1.119 version.