### PR TITLE
SET-330: Missing "merged" to "closed" state in gitlab state conversion

### DIFF
--- a/gitlab/src/main/java/org/jboss/set/aphrodite/repository/services/gitlab/GitLabUtils.java
+++ b/gitlab/src/main/java/org/jboss/set/aphrodite/repository/services/gitlab/GitLabUtils.java
@@ -130,7 +130,9 @@ public class GitLabUtils {
     }
 
     /**
-     * Converts gitlab state into a PullRequestState
+     * Converts a gitlab state into a PullRequestState
+     * Valid gitlab states: opened, closed, locked or merged
+     *
      *
      * @param state The gitlab state
      * @return The aphrodite state
@@ -140,6 +142,7 @@ public class GitLabUtils {
             case "opened":
                 return PullRequestState.OPEN;
             case "closed":
+            case "merged":
                 return PullRequestState.CLOSED;
             default:
                 return PullRequestState.UNDEFINED;


### PR DESCRIPTION
Issue: https://projects.engineering.redhat.com/browse/SET-330

Just a minor change to map the "merged" state to "closed" in the gitlab implementation.