### PR TITLE
override hashCode() and equals() based on trackerId and summary for Issue.

### DIFF
--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/Issue.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/Issue.java
@@ -369,20 +369,33 @@ public class Issue {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o)
+    public boolean equals(Object obj) {
+        if (this == obj)
             return true;
-        if (o == null || getClass() != o.getClass())
+        if (obj == null)
             return false;
-
-        Issue issue = (Issue) o;
-
-        return url.equals(issue.url);
-
+        if (getClass() != obj.getClass())
+            return false;
+        Issue other = (Issue) obj;
+        if (summary == null) {
+            if (other.summary != null)
+                return false;
+        } else if (!summary.equals(other.summary))
+            return false;
+        if (trackerId == null) {
+            if (other.trackerId != null)
+                return false;
+        } else if (!trackerId.equals(other.trackerId))
+            return false;
+        return true;
     }
 
     @Override
     public int hashCode() {
-        return url.hashCode();
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((summary == null) ? 0 : summary.hashCode());
+        result = prime * result + ((trackerId == null) ? 0 : trackerId.hashCode());
+        return result;
     }
 }


### PR DESCRIPTION
I see weird case that when there is issue A in the **x.y.z.GA** version and same issue A in **x.y.z.CR1**, [JiraRelease.getIssues()](https://github.com/jboss-set/aphrodite/blob/2c7b605870f92d214a5bf89c7fd5733645ce53ae/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraRelease.java#L77) could possibly add same issue twice into issue set, because the issue's `hashcode` (from `url.hashCode()`) can change and the calculations can be different. This PR uses simple String type `trackerId` and `summary` instead of `URL` to override both `hashCode()` and `equals()`. it should guarantee same constant result. 