### PR TITLE
[SET-463] Use API keys supplied in the Authorization header to access Bugzilla.

### DIFF
--- a/aphrodite.properties.json.example
+++ b/aphrodite.properties.json.example
@@ -12,8 +12,7 @@
         },
     {
             "url": "https://bugzilla.redhat.com/",
-            "username": "",
-            "password": "",
+            "password": "Your API key value",
             "tracker": "BUGZILLA",
             "defaultIssueLimit": 1
         }

--- a/bugzilla/pom.xml
+++ b/bugzilla/pom.xml
@@ -35,7 +35,12 @@
         <dependency>
             <groupId>org.apache.xmlrpc</groupId>
             <artifactId>xmlrpc-client</artifactId>
-            <version>3.1.3</version>
+            <version>${org.apache.xmlrpc.xmlrpc-client}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-httpclient</groupId>
+            <artifactId>commons-httpclient</artifactId>
+            <version>${commons-httpclient.commons-httpclient}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.set</groupId>

--- a/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaIssueTracker.java
+++ b/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaIssueTracker.java
@@ -68,7 +68,8 @@ public class BugzillaIssueTracker extends AbstractIssueTracker {
             return false;
 
         try {
-            bzClient = new BugzillaClient(baseUrl, config.getUsername(), config.getPassword(), executorService);
+            // TODO update the IssueTrackerConfig attributes
+            bzClient = new BugzillaClient(baseUrl, config.getPassword(), executorService);
         } catch (IllegalStateException e) {
             Utils.logException(LOG, e);
             return false;

--- a/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaQueryBuilder.java
+++ b/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaQueryBuilder.java
@@ -63,14 +63,11 @@ class BugzillaQueryBuilder {
     private static final Log LOG = LogFactory.getLog(BugzillaQueryBuilder.class);
 
     private final SearchCriteria criteria;
-    private final Map<String, Object> loginDetails;
     private final int defaultIssueLimit;
     private Map<String, Object> queryMap;
 
-    BugzillaQueryBuilder(SearchCriteria criteria, Map<String, Object> loginDetails,
-            int defaultIssueLimit) {
+    BugzillaQueryBuilder(SearchCriteria criteria, int defaultIssueLimit) {
         this.criteria = criteria;
-        this.loginDetails = loginDetails;
         this.defaultIssueLimit = defaultIssueLimit;
     }
 
@@ -98,7 +95,6 @@ class BugzillaQueryBuilder {
             queryMap = null;
             return null;
         }
-        queryMap.putAll(loginDetails);
         queryMap.put(RESULT_INCLUDE_FIELDS, RESULT_FIELDS);
         queryMap.put(RESULT_PERMISSIVE_SEARCH, true);
 

--- a/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/IssueWrapper.java
+++ b/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/IssueWrapper.java
@@ -159,11 +159,11 @@ class IssueWrapper {
 
     }
 
-    Map<String, Object> issueToBugzillaBug(Issue issue, Map<String, Object> loginDetails) throws AphroditeException {
+    Map<String, Object> issueToBugzillaBug(Issue issue) throws AphroditeException {
         checkUnsupportedUpdateFields(issue);
         checkUnsupportedIssueStatus(issue);
 
-        Map<String, Object> params = new HashMap<>(loginDetails);
+        Map<String, Object> params = new HashMap<>();
         issue.getTrackerId().ifPresent(trackerId -> params.put(ISSUE_IDS, trackerId));
         issue.getSummary().ifPresent(summary -> params.put(SUMMARY, summary));
         issue.getProduct().ifPresent(product -> params.put(PRODUCT, product));

--- a/bugzilla/src/test/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BZIssueWrapperTest.java
+++ b/bugzilla/src/test/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BZIssueWrapperTest.java
@@ -72,7 +72,6 @@ public class BZIssueWrapperTest {
     private URL bugzillaURL;
     private URL bz01URL;
     private Map<String, Object> bz01;
-    private Map<String, Object> loginMap;
     private Issue issue01;
 
     private IssueWrapper wrapper = new IssueWrapper();
@@ -84,10 +83,6 @@ public class BZIssueWrapperTest {
 
         bz01 = createTestBZ01();
         issue01 = createTestIssue01(bz01URL);
-
-        loginMap = new HashMap<>();
-        loginMap.put(BugzillaFields.LOGIN, "user");
-        loginMap.put(BugzillaFields.PASSWORD, "pass");
     }
 
     @Test
@@ -109,7 +104,7 @@ public class BZIssueWrapperTest {
 
     @Test
     public void validIssueToBZTest() throws AphroditeException {
-        Map<String, Object> result = wrapper.issueToBugzillaBug(issue01, loginMap);
+        Map<String, Object> result = wrapper.issueToBugzillaBug(issue01);
         result.put(BugzillaFields.CREATION_TIME, getCreationDate());
 
         assertNotNull(result);
@@ -119,15 +114,7 @@ public class BZIssueWrapperTest {
     @Test
     public void nullIssuetoBZTest() throws AphroditeException {
         expectedException.expect(NullPointerException.class);
-        Map<String, Object> result = wrapper.issueToBugzillaBug(null, loginMap);
-
-        assertNull(result);
-    }
-
-    @Test
-    public void nullLoginIssuetoBZTest() throws AphroditeException {
-        expectedException.expect(NullPointerException.class);
-        Map<String, Object> result = wrapper.issueToBugzillaBug(issue01, null);
+        Map<String, Object> result = wrapper.issueToBugzillaBug(null);
 
         assertNull(result);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -104,14 +104,16 @@
         <jdk.min.version>1.8</jdk.min.version>
 
         <!-- Dependency versions, please keep alphabetically -->
+        <com.squareup.okhttp.okhttp-urlconnection.version>3.14.9</com.squareup.okhttp.okhttp-urlconnection.version>
         <commons.logging.version>1.1.3</commons.logging.version>
+        <commons-httpclient.commons-httpclient>3.1</commons-httpclient.commons-httpclient>
         <javax.json.version>1.0.4</javax.json.version>
         <junit.version>4.13.1</junit.version>
+        <org.apache.xmlrpc.xmlrpc-client>3.1.3</org.apache.xmlrpc.xmlrpc-client>
         <org.gitlab4j.gitlab4j-api.version>4.14.30</org.gitlab4j.gitlab4j-api.version>
         <org.mockito.version>1.10.19</org.mockito.version>
         <org.wildfly.checkstyle-config.version>1.0.4.Final</org.wildfly.checkstyle-config.version>
         <org.kohsuke.github-api.version>1.119</org.kohsuke.github-api.version>
-        <com.squareup.okhttp.okhttp-urlconnection.version>3.14.9</com.squareup.okhttp.okhttp-urlconnection.version>
     </properties>
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SET-463 

Applications making API calls to Bugzilla may no longer authenticate using passwords or supplying API keys in call parameters. Instead, API keys must be supplied in the Authorization header.  

This remove old authentication login via username and password in call parameters. It now must use API keys supplied in the Authorization header to access Bugzilla.