### PR TITLE
SET-556: retrieve a list of new issues since a given date

### DIFF
--- a/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaQueryBuilder.java
+++ b/bugzilla/src/main/java/org/jboss/set/aphrodite/issue/trackers/bugzilla/BugzillaQueryBuilder.java
@@ -79,7 +79,7 @@ class BugzillaQueryBuilder {
 
         criteria.getAssignee().ifPresent(assignee -> queryMap.put(ASSIGNEE, assignee));
         criteria.getReporter().ifPresent(reporter -> queryMap.put(REPORTER, reporter));
-        criteria.getLastUpdated().ifPresent(date -> queryMap.put(LAST_UPDATED, date.atStartOfDay().toString()));
+        criteria.getStartDate().ifPresent(date -> queryMap.put(LAST_UPDATED, date.atStartOfDay().toString()));
         criteria.getProduct().ifPresent(product -> queryMap.put(PRODUCT, product));
         criteria.getComponent().ifPresent(component -> queryMap.put(COMPONENT, component));
         criteria.getRelease().ifPresent(release -> {

--- a/domain/src/main/java/org/jboss/set/aphrodite/domain/SearchCriteria.java
+++ b/domain/src/main/java/org/jboss/set/aphrodite/domain/SearchCriteria.java
@@ -42,13 +42,14 @@ public class SearchCriteria {
     private final Stage stage;
     private final Release release;
     private final Map<Stream, FlagStatus> streams;
-    private final LocalDate lastUpdated;
+    private final LocalDate startDate;
+    private final LocalDate endDate;
     private final Integer maxResults;
     private final Set<String> labels;
 
     private SearchCriteria(IssueStatus status, String assignee, String reporter, String product,
-            String component, Stage stage, Release release, Map<Stream, FlagStatus> streams,
-            LocalDate lastUpdated, Integer maxResults, Set<String> labels) {
+                           String component, Stage stage, Release release, Map<Stream, FlagStatus> streams,
+                           LocalDate startDate, LocalDate endDate, Integer maxResults, Set<String> labels) {
         this.status = status;
         this.assignee = assignee;
         this.reporter = reporter;
@@ -57,12 +58,16 @@ public class SearchCriteria {
         this.stage = stage;
         this.release = release;
         this.streams = streams;
-        this.lastUpdated = lastUpdated;
+        this.startDate = startDate;
+        this.endDate = endDate;
         this.maxResults = maxResults;
         this.labels = labels;
 
-        if (lastUpdated != null && lastUpdated.isAfter(LocalDate.now()))
-            throw new IllegalArgumentException("lastUpdated cannot be in the future.");
+        if (startDate != null && startDate.isAfter(LocalDate.now()))
+            throw new IllegalArgumentException("startDate cannot be in the future.");
+
+        if (endDate != null && endDate.isAfter(LocalDate.now()))
+            throw new IllegalArgumentException("endDate cannot be in the future.");
     }
 
     public Optional<IssueStatus> getStatus() {
@@ -97,8 +102,11 @@ public class SearchCriteria {
         return Optional.ofNullable(streams);
     }
 
-    public Optional<LocalDate> getLastUpdated() {
-        return Optional.ofNullable(lastUpdated);
+    public Optional<LocalDate> getStartDate() {
+        return Optional.ofNullable(startDate);
+    }
+    public Optional<LocalDate> getEndDate() {
+        return Optional.ofNullable(endDate);
     }
 
     public Optional<Integer> getMaxResults() {
@@ -111,7 +119,7 @@ public class SearchCriteria {
 
     public boolean isEmpty() {
         return status == null && assignee == null && reporter == null && product == null && component == null && stage == null
-                && release == null && streams == null && lastUpdated == null && maxResults == null;
+                && release == null && streams == null && startDate == null && endDate == null && maxResults == null;
     }
 
     public static class Builder {
@@ -125,6 +133,7 @@ public class SearchCriteria {
         private Release release;
         private Map<Stream, FlagStatus> streams;
         private LocalDate startDate;
+        private LocalDate endDate;
         private Integer maxResults;
         private Set<String> labels;
 
@@ -173,6 +182,11 @@ public class SearchCriteria {
             return this;
         }
 
+        public Builder setEndDate(LocalDate endDate) {
+            this.endDate = endDate;
+            return this;
+        }
+
         public Builder setMaxResults(Integer maxResults) {
             this.maxResults = maxResults;
             return this;
@@ -185,7 +199,7 @@ public class SearchCriteria {
 
         public SearchCriteria build() {
             return new SearchCriteria(status, assignee, reporter, product, component, stage, release,
-                    streams, startDate, maxResults, labels);
+                    streams, startDate, endDate, maxResults, labels);
         }
     }
 }

--- a/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/CandidateRelease.java
+++ b/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/CandidateRelease.java
@@ -53,9 +53,11 @@ public class CandidateRelease {
         return CR_VERSION.matcher(releaseCandidateName).find();
     }
 
-    Version releaseCandidateVersion;
+    private String project;
+    private Version releaseCandidateVersion;
 
-    public CandidateRelease(Version version) {
+    public CandidateRelease(String project, Version version) {
+        this.project = project;
         releaseCandidateVersion = version;
     }
 
@@ -73,7 +75,7 @@ public class CandidateRelease {
         if (issues == null) {
             //fetch
             JiraIssueTracker issueTrackerService = SimpleContainer.instance().lookup(JiraIssueTracker.class.getSimpleName(), JiraIssueTracker.class);
-            issues = issueTrackerService.getIssues(releaseCandidateVersion);
+            issues = issueTrackerService.getIssues(project, releaseCandidateVersion);
         }
         return issues;
     }

--- a/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraQueryBuilder.java
+++ b/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraQueryBuilder.java
@@ -46,7 +46,7 @@ class JiraQueryBuilder {
         criteria.getReporter().ifPresent(reporter -> addCriteriaToJQL("reporter = ", reporter, " AND ", sb));
         criteria.getComponent().ifPresent(component -> addCriteriaToJQL("component = ", component, " AND ", sb));
         criteria.getProduct().ifPresent(product -> addCriteriaToJQL("project = ", product, " AND ", sb));
-        criteria.getLastUpdated().ifPresent(date -> {
+        criteria.getStartDate().ifPresent(date -> {
             String formattedDate = date.atStartOfDay().format((DateTimeFormatter.ISO_LOCAL_DATE));
             addCriteriaToJQL("updated >= ", formattedDate, " AND ", sb);
         });
@@ -69,6 +69,23 @@ class JiraQueryBuilder {
                                         entry.getValue().getSymbol(), " AND ", sb)));
 
         criteria.getLabels().forEach(label->addCriteriaToJQL("labels = ", label, " AND ", sb));
+        return sb.toString();
+    }
+
+    String getSearchJQLFromTo(SearchCriteria criteria) {
+        StringBuilder sb = new StringBuilder();
+        addCriteriaToJQL("project = ", criteria.getProduct().orElse(null), " AND ", sb);
+        addCriteriaToJQL("fixVersion = ", criteria.getRelease().get().getVersion().orElse(null), " AND ", sb);
+        criteria.getStartDate().ifPresent(startDate -> {
+            addCriteriaToJQL("fixVersion was not ", criteria.getRelease().get().getVersion().orElse(null), " AND ", sb);
+            String formattedDate = startDate.atStartOfDay().format((DateTimeFormatter.ISO_LOCAL_DATE));
+            addCriteriaToJQL("", formattedDate, " BEFORE ", sb);
+        });
+        criteria.getEndDate().ifPresent(endDate -> {
+            addCriteriaToJQL("fixVersion was ", criteria.getRelease().get().getVersion().orElse(null), " AND ", sb);
+            String formattedDate = endDate.atStartOfDay().format((DateTimeFormatter.ISO_LOCAL_DATE));
+            addCriteriaToJQL("", formattedDate, " BEFORE ", sb);
+        });
         return sb.toString();
     }
 

--- a/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraRelease.java
+++ b/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraRelease.java
@@ -28,6 +28,7 @@ import org.jboss.set.aphrodite.simplecontainer.SimpleContainer;
 import org.jboss.set.aphrodite.spi.NotFoundException;
 
 import javax.naming.NameNotFoundException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -98,7 +99,7 @@ public class JiraRelease {
             if (CandidateRelease.isGA(version.getName())) {
                 try {
                     JiraRelease release = new JiraRelease(version, new ArrayList<>());
-                    release.addCandidateRelease(new CandidateRelease(version));
+                    release.addCandidateRelease(new CandidateRelease(PROJECT_NAME, version));
                     releases.put(CandidateRelease.extractVersion(version.getName()), release);
 
                 } catch (NotFoundException e) {
@@ -113,7 +114,7 @@ public class JiraRelease {
                 try {
                     String nameGA = CandidateRelease.extractVersion(version.getName());
                     if(releases.containsKey(nameGA)) {
-                        releases.get(nameGA).addCandidateRelease(new CandidateRelease(version));
+                        releases.get(nameGA).addCandidateRelease(new CandidateRelease(PROJECT_NAME, version));
                     }
                 } catch (NotFoundException e) {
                     e.printStackTrace();
@@ -124,4 +125,9 @@ public class JiraRelease {
         return releases.values();
     }
 
+    public List<Issue> getNewIssues(LocalDate from, LocalDate to) throws NameNotFoundException {
+        JiraIssueTracker issueTrackerService = SimpleContainer.instance().lookup(JiraIssueTracker.class.getSimpleName(), JiraIssueTracker.class);
+
+        return issueTrackerService.getIssuesAddedToVersion(PROJECT_NAME, version, from, to);
+    }
 }


### PR DESCRIPTION
Issue: [SET-556](https://issues.redhat.com/browse/SET-556)

This is mostly intended to be used after we get the list of all issues in a payload, so we can find out which are new. The search API doesn't let us retrieve the changelog (well the API does, the client doesn't have it implemented), so we have to make a separate request.