### PR TITLE
Find new Jira release version format for EAP 8 CP

### DIFF
--- a/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/CandidateRelease.java
+++ b/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/CandidateRelease.java
@@ -39,10 +39,10 @@ public class CandidateRelease {
     private List<Issue> issues;
 
     public static final Pattern GA_VERSION = Pattern.compile("^[7-9]+\\.[0-9]+\\.[0-9]+\\.GA$");
-
     public static final Pattern VERSION_PART = Pattern.compile("^[7-9]+\\.[0-9]+\\.[0-9]+");
-
     public static final Pattern CR_VERSION = Pattern.compile("^[7-9]*\\.[0-9]*\\.[0-9]*\\.CR[0-9]+$");
+    public static final Pattern CP_UPDATE_VERSION = Pattern.compile("^[8-9]+\\.[0-9]+\\s+Update\\s+[0-9]+$");
+    public static final Pattern CP_UPDATE_VERSION_PART = Pattern.compile("(^[8-9]+)\\.([0-9]+)\\s+Update\\s+([0-9]+)$");
 
 
     public static boolean isGA(String releaseCandidateName) {
@@ -51,6 +51,10 @@ public class CandidateRelease {
 
     public static boolean isCR(String releaseCandidateName) {
         return CR_VERSION.matcher(releaseCandidateName).find();
+    }
+
+    public static boolean isCPUpdate(String releaseCandidateName) {
+        return CP_UPDATE_VERSION.matcher(releaseCandidateName).find();
     }
 
     private String project;
@@ -70,6 +74,15 @@ public class CandidateRelease {
 
         return matcher.group();
     }
+
+    public static String extractCPUpdateVersion(String name) throws NotFoundException {
+        Matcher matcher = CP_UPDATE_VERSION_PART.matcher(name);
+        if (!matcher.find()) {
+            throw new NotFoundException();
+        }
+        return matcher.group(1) + "." + matcher.group(2) + "." + matcher.group(3);
+    }
+
 
     public List<Issue> getIssues() throws NameNotFoundException {
         if (issues == null) {

--- a/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraRelease.java
+++ b/jira/src/main/java/org/jboss/set/aphrodite/issue/trackers/jira/JiraRelease.java
@@ -122,6 +122,19 @@ public class JiraRelease {
             }
         });
 
+        // Since EAP 8 first CP, the version format has been changed to "8.0 Update 1"
+        versions.forEach(version -> {
+            if (CandidateRelease.isCPUpdate(version.getName())) {
+                try {
+                    JiraRelease release = new JiraRelease(version, new ArrayList<>());
+                    release.addCandidateRelease(new CandidateRelease(PROJECT_NAME, version));
+                    releases.put(CandidateRelease.extractCPUpdateVersion(version.getName()), release);
+                } catch (NotFoundException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+
         return releases.values();
     }
 

--- a/jira/src/test/java/org/jboss/set/aphrodite/issue/trackers/jira/CandidateJiraReleaseTest.java
+++ b/jira/src/test/java/org/jboss/set/aphrodite/issue/trackers/jira/CandidateJiraReleaseTest.java
@@ -50,8 +50,27 @@ public class CandidateJiraReleaseTest {
     }
 
     @Test
+    public void testIsCPUpdateVersion() {
+        Assert.assertTrue(CandidateRelease.isCPUpdate("8.0 Update 1"));
+        Assert.assertTrue(CandidateRelease.isCPUpdate("8.1 Update 2"));
+        Assert.assertTrue(CandidateRelease.isCPUpdate("8.3 Update 10"));
+        Assert.assertTrue(CandidateRelease.isCPUpdate("8.4 Update 11"));
+
+        Assert.assertFalse(CandidateRelease.isCPUpdate("7.4 Update 1"));
+        Assert.assertFalse(CandidateRelease.isCPUpdate(" 8.0 Update 1"));
+    }
+
+    @Test
     public void extractVersion() throws NotFoundException {
         Assert.assertEquals("7.4.22", CandidateRelease.extractVersion("7.4.22.GA"));
         Assert.assertEquals("7.4.22", CandidateRelease.extractVersion("7.4.22.CR1"));
+    }
+
+    @Test
+    public void extractCPUpdateVersion() throws NotFoundException {
+        Assert.assertEquals("8.0.1", CandidateRelease.extractCPUpdateVersion("8.0 Update 1"));
+        Assert.assertEquals("8.1.2", CandidateRelease.extractCPUpdateVersion("8.1 Update 2"));
+        Assert.assertEquals("8.2.11", CandidateRelease.extractCPUpdateVersion("8.2 Update 11"));
+        Assert.assertEquals("8.3.12", CandidateRelease.extractCPUpdateVersion("8.3 Update 12"));
     }
 }


### PR DESCRIPTION
Since EAP 8 first CP, the release version format has been changed from `Major.Minor.Micro.GA` to `8.0 Update 1`

For instance https://issues.redhat.com/projects/JBEAP/versions/12399052

This change allows to properly find and load such Jira release versions.